### PR TITLE
fix: resolve #12 - BUG: Pin GitHub Actions to commit SHAs to prevent supply-cha

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,8 +8,8 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v16
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8  # v16.0.0
         with:
           globs: |
             docs/**/*.md
@@ -18,8 +18,8 @@ jobs:
   mermaid-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
         with:
           node-version: "20"
       - name: Install mermaid-cli


### PR DESCRIPTION
## Summary

GitHub Actions in `.github/workflows/lint.yml` were pinned to floating version tags (`@v4`, `@v16`). A floating tag can be silently re-pointed to a malicious commit, enabling arbitrary code execution in CI with repository write access. This is a known supply-chain attack vector documented by GitHub's own security hardening guide and SLSA best practices.

This change replaces all floating tag references with immutable 40-character commit SHAs, eliminating that attack surface at zero functional cost.

## Changes

`.github/workflows/lint.yml`
- `actions/checkout@v4` -> `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
- `DavidAnson/markdownlint-cli2-action@v16` -> `DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8` (v16.0.0)
- `actions/setup-node@v4` -> `actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af` (v4.1.0)

All SHA pins carry an inline `# vX.Y.Z` comment so the human-readable version remains visible.

`.github/dependabot.yml` (new file)
- Adds Dependabot config for the `github-actions` ecosystem, scheduled weekly. This ensures SHA pins stay current without manual intervention — Dependabot will open PRs to advance the pinned SHA when new releases are published.

## Testing

1. Push the branch and confirm the `markdownlint` and `mermaid-check` jobs both pass in CI.
2. Verify no floating tags remain: `grep "uses:" .github/workflows/lint.yml` should show only full 40-char SHAs.
3. After merge, confirm Dependabot is active under the repository's Security tab -> Dependabot alerts.

Closes #12