### PR TITLE
fix: resolve #15 - FEATURE: Add Entra External ID and B2C section to Identity &

### DIFF
--- a/docs/Azure-CheatSheet.md
+++ b/docs/Azure-CheatSheet.md
@@ -424,6 +424,21 @@ graph TD
 
 ---
 
+## Entra Identity Scenarios
+
+| Scenario | Solution | Tenant Type |
+|---|---|---|
+| Employee / workforce identity | Entra ID (workforce tenant) | Workforce |
+| Partner / vendor B2B access | Entra B2B (guest users) | Workforce |
+| Customer-facing app identity | Entra External ID (external tenant) | External / CIAM |
+
+> **Exam tip:** Entra External ID is the successor to Azure AD B2C for new customer identity
+> (CIAM) projects. Existing B2C tenants continue to be supported, but new designs should target
+> Entra External ID (external tenant). Do not confuse B2B guest users (workforce tenant) with
+> External ID (separate external tenant).
+
+---
+
 ## RBAC
 
 | Concept | Description |


### PR DESCRIPTION
## Summary

The Identity & Access section of the cheat sheet covered workforce identity (Entra ID, PIM, RBAC)
thoroughly but had no coverage of customer-facing identity scenarios. AZ-305 tests candidates on
the distinction between workforce tenants, B2B guest federation, and external/CIAM tenants via
Entra External ID. Without this, candidates had a gap when facing identity architecture questions
that involve customer apps.

## Changes

**docs/Azure-CheatSheet.md — Identity & Access section**

Added a new "Entra Identity Scenarios" subsection immediately before the RBAC block, containing:

- A three-row comparison table mapping each identity scenario (employee, partner B2B,
  customer-facing) to its correct Azure solution and tenant type. This makes the workforce vs.
  external tenant boundary explicit at a glance.
- An exam tip callout clarifying that Entra External ID is the successor to Azure AD B2C for new
  CIAM projects, that existing B2C tenants remain supported, and that B2B guest users (workforce
  tenant) must not be confused with External ID (separate external tenant). This directly addresses
  the most likely AZ-305 decision-point trap.

No other sections were modified.

## Testing

This is a documentation-only repository with no build or test suite. Verify as follows:

1. Open `docs/Azure-CheatSheet.md` in VS Code with the "Markdown Preview Mermaid Support"
   extension active and confirm the table renders correctly.
2. Confirm the exam tip blockquote appears beneath the table and above the RBAC section.
3. Review the three scenario rows for accuracy against official Microsoft documentation:
   - [Entra External ID overview](https://learn.microsoft.com/en-us/entra/external-id/overview)
   - [Compare B2B and External ID](https://learn.microsoft.com/en-us/entra/external-id/external-identities-overview)
4. Verify no surrounding Mermaid blocks or tables were accidentally disrupted by checking the
   sections immediately above and below the insertion point.

Closes #15