### PR TITLE
fix: resolve #16 - FEATURE: Add dedicated Azure Container Apps section with com

### DIFF
--- a/docs/Azure-CheatSheet.md
+++ b/docs/Azure-CheatSheet.md
@@ -441,6 +441,37 @@ graph TD
 
 ---
 
+## Azure Container Apps vs AKS vs ACI
+
+| Dimension | ACI | ACA | AKS |
+|---|---|---|---|
+| **Control plane** | None — single container group | Managed (Envoy/KEDA/Dapr hidden) | Full K8s API access |
+| **Scale trigger** | Manual / ARM template | KEDA (HTTP, queue, cron, custom) | HPA / KEDA (self-managed) |
+| **Dapr integration** | No | Native sidecar injection | Manual Dapr install |
+| **Revision management** | No | Yes — traffic split across revisions | Rolling deploy via K8s |
+| **VNet integration** | Yes (inject into subnet) | Yes (environment-level) | Yes (CNI plugin) |
+| **Cost model** | Per second, vCPU + memory | Per vCPU-s + memory-s (scale to zero) | Node pool VMs (always on) |
+| **Ops overhead** | Minimal | Low | High (cluster upgrades, node pools) |
+
+```mermaid
+flowchart TD
+    A[Container workload?] --> B{Need K8s API\nor custom controllers?}
+    B -- Yes --> AKS[Azure Kubernetes Service]
+    B -- No --> C{Need event-driven scale\nor Dapr without K8s ops?}
+    C -- Yes --> ACA[Azure Container Apps]
+    C -- No --> D{Single burst container\nno long-lived scale?}
+    D -- Yes --> ACI[Azure Container Instances]
+    D -- No --> ACA
+```
+
+> **Exam tip:** ACA uses KEDA under the hood and supports **scale-to-zero** for HTTP and
+> queue-based triggers — similar to Consumption plan Functions but for containerised workloads.
+> Choose ACA over Functions when you need: a custom runtime, Dapr service invocation, or
+> revision-based traffic splitting. Choose AKS when the scenario requires direct Kubernetes
+> API access, custom admission webhooks, or specific CNI configuration.
+
+---
+
 ## Virtual Machine SKU Families
 
 | Family | Purpose |


### PR DESCRIPTION
## Summary

Issue #16 identified that Azure Container Apps (ACA) had only a single-row entry in the Compute Options table, leaving a meaningful gap for AZ-305 candidates. The exam regularly presents scenarios requiring a justified choice between ACI, ACA, and AKS — and the key differentiators (KEDA scaling, Dapr integration, revision management, environment model) were entirely absent from the cheat sheet.

This PR adds a dedicated ACA section directly in the Compute chapter to close that gap.

## Changes

**`docs/Azure-CheatSheet.md` — Compute section**

- Added a three-way comparison table (ACI vs ACA vs AKS) covering: control plane, scale trigger, Dapr integration, revision management, VNet integration, cost model, and ops overhead. Each dimension maps to a likely exam decision point.
- Added a Mermaid `flowchart TD` decision tree that guides candidates from a container workload question down to the right service: K8s API access → AKS, event-driven scale / Dapr without K8s ops → ACA, single burst with no persistence → ACI.
- Added an exam tip callout explaining ACA's KEDA-based scale-to-zero, how it compares to Consumption plan Functions, and when to prefer ACA over Functions or AKS. This directly addresses the scenario where a candidate must justify ACA vs a sibling managed service.

## Testing

1. Open `docs/Azure-CheatSheet.md` in VS Code with the "Markdown Preview Mermaid Support" extension active and confirm the flowchart renders without errors.
2. Paste the Mermaid block into the [Mermaid Live Editor](https://mermaid.live) to validate syntax independently.
3. Review the comparison table for alignment and confirm all seven dimension rows are present.
4. Confirm the section appears after the Azure Functions Hosting Plans section and before the Virtual Machine SKU Families section.

Closes #16