### PR TITLE
fix: resolve #17 - FEATURE: Expand README with explicit contributor guidelines 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,46 @@ decision-reference tool.
 When editing or adding material:
 
 - Keep explanations concise and comparison-oriented.
+- Section headings: top-level domain names in ALL CAPS (`# NETWORKING`).
+  Sub-topics as `##`. Do not use Title Case for top-level section headings.
 - Prefer tables when comparing Azure services, tiers, or design options.
+  Use these column templates:
+
+  Networking / compute services:
+  | Service | Layer | Scope | Use Case | Key Feature |
+
+  Data / storage services:
+  | Service | Type | Best For | Key Feature |
+
+  Consistency columns (always present): Service, Key Feature.
+  Do not add free-form columns not in the template above.
+
 - Use short exam-tip callouts only when they clarify a likely decision point.
+  Format: place the callout immediately after the relevant table, using:
+
+  > **Exam tip:** Choose Azure Front Door when the requirement mentions
+  > global HTTP load balancing, WAF, or SSL offload at the edge.
+
+  Do not use plain blockquotes, bold sentences, or note/warning admonitions
+  for exam tips.
+
 - Use Mermaid diagrams for branching decision flows where a visual aid is more
-  useful than prose alone.
+  useful than prose alone. Choose the variant by purpose:
+
+  | Purpose                        | Directive       |
+  |--------------------------------|-----------------|
+  | Decision flows (if/else trees) | flowchart TD    |
+  | Hierarchy / ecosystem maps     | graph TD        |
+  | Connectivity / network paths   | graph LR        |
+
+  Example decision flow:
+
+  ```mermaid
+  flowchart TD
+      A[Need load balancing?] -->|Global HTTP| B[Azure Front Door]
+      A -->|Regional TCP/UDP| C[Azure Load Balancer]
+  ```
+
 - Avoid documenting features or claims that are not yet reflected in the
   repository content.
 
@@ -67,6 +103,8 @@ For pull requests:
 
 - Keep changes scoped to one improvement area where possible.
 - Explain what section changed and why it improves the cheat sheet for readers.
+- Run `npx markdownlint-cli2 "**/*.md"` locally before opening a PR to
+  catch formatting violations before CI runs them.
 - Verify that Markdown formatting and Mermaid blocks still render cleanly on
   GitHub.
 


### PR DESCRIPTION
## Summary

The Contributing section of `README.md` described intent but provided no
concrete syntax examples or authoring conventions. Contributors had to
reverse-engineer table column ordering, exam-tip callout syntax, and Mermaid
diagram variants from existing content — leading to inconsistencies that add
unnecessary review overhead.

This PR codifies the four main authoring conventions (section headings, table
column templates, exam-tip format, Mermaid variant selection) with explicit
before/after examples directly in the Contributing section.

## Changes

**Section heading convention**
Added an explicit rule: top-level domain names in ALL CAPS (`# NETWORKING`),
sub-topics as `##`. Prevents Title Case drift in new sections.

**Table column templates**
Defined two column templates — one for networking/compute services, one for
data/storage services — anchored by the always-present `Service` and
`Key Feature` columns. Removes ambiguity about free-form column additions.

**Exam-tip callout format**
Specified the exact blockquote syntax (`> **Exam tip:** ...`) and placement
(immediately after the relevant table). Explicitly disallows plain blockquotes,
bold sentences, and admonitions so the format stays uniform.

**Mermaid variant selection**
Added a lookup table mapping diagram purpose to directive
(`flowchart TD` / `graph TD` / `graph LR`) and a minimal working example.
Eliminates `flowchart` vs `graph` ambiguity that currently requires review
corrections.

**Linting step**
Added `npx markdownlint-cli2 "**/*.md"` to the PR checklist so contributors
catch formatting violations locally before CI runs them.

## Testing

1. Render `README.md` on GitHub (or via the VS Code Markdown Preview with the
   Mermaid Support extension) and confirm the example Mermaid block displays
   correctly.
2. Run `npx markdownlint-cli2 "**/*.md"` from the repository root and confirm
   zero violations.
3. Confirm the README CI badge and existing structure are untouched.

Closes #17