### PR TITLE
fix: resolve #19 - FEATURE: Add AZ-104 and AZ-900 overlap callouts to help read

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ decision-making. Configuration walkthroughs, portal screenshots, and hands-on
 labs are intentionally out of scope. Other Azure exams may overlap with parts
 of this material, but the repository is not yet organized around those tracks.
 
+### Exam Overlap
+
+| Exam | Focus | Relevant Sections |
+|------|-------|-------------------|
+| AZ-900 | Fundamentals | Networking (overview), Storage, Compute, Identity & Access (Entra basics) |
+| AZ-104 | Administrator | All sections — administrator-level depth on RBAC, Networking, HA & DR |
+| AZ-305 | Architect | All sections — architectural decision-making focus |
+
 ## Repository Structure
 
 - [`docs/Azure-CheatSheet.md`](docs/Azure-CheatSheet.md) - the main cheat sheet

--- a/docs/Azure-CheatSheet.md
+++ b/docs/Azure-CheatSheet.md
@@ -22,6 +22,9 @@
 
 # NETWORKING
 
+> Also relevant for: **AZ-900** (foundational networking concepts) and **AZ-104**
+> (VNet design, NSGs, load balancing administration).
+
 ## Load Balancers
 
 | Service | Layer | Scope | Use Case | Key Feature |
@@ -488,6 +491,9 @@ flowchart TD
 
 # IDENTITY & ACCESS
 
+> Also relevant for: **AZ-900** (Entra ID basics, authentication concepts) and
+> **AZ-104** (RBAC assignments, role definitions, Managed Identity administration).
+
 ## Entra ID (Azure AD) Concepts
 
 | Concept | Description |
@@ -546,6 +552,9 @@ flowchart TD
 ---
 
 # HIGH AVAILABILITY & DISASTER RECOVERY
+
+> Also relevant for: **AZ-104** (Availability Sets, Availability Zones, Backup,
+> Site Recovery administration).
 
 ## Key Concepts
 


### PR DESCRIPTION
## Summary

Readers arriving at this repository from adjacent Azure exam tracks — AZ-900 (Fundamentals) and AZ-104 (Administrator) — had no indication of which sections were relevant to them. The repository scope note explicitly acknowledged these tracks were unsupported but offered no bridge. This change adds lightweight overlap indicators so the repository serves a broader audience without restructuring or diluting the AZ-305 focus.

## Changes

**README.md — Exam Overlap table**
Added a three-row table under the existing scope paragraph mapping each exam code (AZ-900, AZ-104, AZ-305) to its focus area and the relevant cheat sheet sections. This gives readers a single, scannable reference point before they dive into the content.

**docs/Azure-CheatSheet.md — Exam-tip callouts in three sections**
Added `> Also relevant for:` blockquote callouts at the top of:
- **Networking** — flags AZ-900 foundational networking and AZ-104 VNet/NSG/load-balancing administration.
- **Identity & Access** — flags AZ-900 Entra ID basics and AZ-104 RBAC/Managed Identity administration.
- **High Availability & Disaster Recovery** — flags AZ-104 Availability Sets, Availability Zones, Backup, and Site Recovery.

These three sections were chosen because they carry the highest administrator-level operational depth, making them the most immediately useful to AZ-104 candidates.

## Testing

1. Open `README.md` on GitHub — confirm the Exam Overlap table renders with three rows and correct column alignment.
2. Open `docs/Azure-CheatSheet.md` on GitHub — confirm the three callout blocks render as blockquotes beneath the Networking, Identity & Access, and High Availability & Disaster Recovery headings.
3. Confirm no existing content was removed or reformatted.
4. If using VS Code with the Markdown Preview Mermaid Support extension, verify local preview renders without errors.

Closes #19