### PR TITLE
fix: resolve #38 - FEATURE: Add a Messaging & Integration decision flow for Log

### DIFF
--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -718,6 +718,17 @@ flowchart TD
 | **Azure Functions** | Stateless compute, event-driven microservices | Many triggers (HTTP, queue, timer, etc.) | Stateless by default | Consumption / Premium |
 | **Durable Functions** | Long-running, stateful orchestrations in code | Orchestrator / Activity / Entity | Stateful (via storage) | Consumption (includes storage cost) |
 
+```mermaid
+flowchart TD
+    A[Integration or automation need?] --> B{Low-code / SaaS connectors?}
+    B -- Yes --> LA[Logic Apps]
+    B -- No --> C{Long-running or stateful workflow?}
+    C -- Yes --> DF[Durable Functions]
+    C -- No --> AF[Azure Functions]
+```
+
+> **Exam tip:** Choose Logic Apps when the requirement mentions low-code orchestration or pre-built SaaS connectors. Choose Durable Functions for long-running, stateful, or fan-out/fan-in patterns written in code. Choose Azure Functions for stateless, event-driven compute with no orchestration requirement.
+
 ## Exam Tips
 
 > **Dead-Letter Queues (DLQ):** Messages are moved to the DLQ when TTL expires, max delivery count is exceeded, or the message is explicitly dead-lettered by the receiver. Monitor DLQ depth via Azure Monitor metrics or Service Bus Explorer — a growing DLQ indicates poison messages or consumer failures.


### PR DESCRIPTION
## Summary

The MESSAGING & INTEGRATION section of the AZ-305 cheat sheet compared Logic Apps, Azure Functions, and Durable Functions in a table but lacked a Mermaid decision flowchart. Every other major section with comparable architectural complexity already has a decision flow to reinforce the mental model for case-study questions. This omission created a study-aid gap and an inconsistency in the document structure.

## Changes

**`docs/AZ-305_CheatSheet.md`**

- Added a `flowchart TD` Mermaid block immediately after the Logic Apps / Azure Functions / Durable Functions comparison table (around line 719). The flow guides the reader through the three key decision gates: low-code/SaaS connector need → stateful/long-running requirement → stateless event-driven compute.
- Added an exam-tip callout directly below the diagram, following the formatting convention established in AGENTS.md. The tip maps each terminal node back to the exam pattern most likely to appear in AZ-305 case-study questions.

No structural changes were made. The insertion is self-contained and does not affect surrounding content.

## Testing

1. Render check — open `docs/AZ-305_CheatSheet.md` in VS Code with the "Markdown Preview Mermaid Support" extension and confirm the flowchart renders without syntax errors.
2. Markdownlint — run `npx markdownlint-cli2 "**/*.md"` locally and confirm zero new errors are introduced.
3. CI — the mermaid-check job in the GitHub Actions workflow must pass for the new diagram block.
4. Content review — verify the three decision paths (Logic Apps, Durable Functions, Azure Functions) match the table directly above and the exam tip accurately reflects the AZ-305 exam guidance.

Closes #38