### PR TITLE
fix: resolve #40 - BUG: Fix pinned action SHA for lychee-action (link-check job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,8 +32,8 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: lycheeverse/lychee-action@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2
         with:
           args: --verbose --no-progress docs/**/*.md README.md
           fail: true


### PR DESCRIPTION
## Summary

The `link-check` job in `.github/workflows/lint.yml` referenced two third-party actions by mutable version tags (`actions/checkout@v6` and `lycheeverse/lychee-action@v2`). Mutable tags can be silently redirected by upstream maintainers, creating a supply-chain attack vector. Every other job in the workflow already pins actions to full 40-character commit SHAs — this fix brings `link-check` into line with that convention.

## Changes

- `.github/workflows/lint.yml` — replaced `actions/checkout@v6` with `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2`. Pins the checkout step to an immutable SHA while retaining the version comment for readability.
- `.github/workflows/lint.yml` — replaced `lycheeverse/lychee-action@v2` with `lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2`. Pins the link-checker to an immutable SHA, eliminating the supply-chain inconsistency.

Both changes match the inline comment style already used by the `markdownlint` and `mermaid-check` jobs.

## Testing

1. Open the Actions tab after the PR is created and confirm the `link-check` job triggers and passes.
2. Confirm the `markdownlint` job still passes (no collateral changes).
3. Optionally: inspect the resolved SHAs against the upstream release tags on GitHub to verify they map to the intended versions:
   - `actions/checkout` → https://github.com/actions/checkout/releases/tag/v6.0.2
   - `lycheeverse/lychee-action` → https://github.com/lycheeverse/lychee-action/releases/tag/v2

Closes #40