### PR TITLE
fix: resolve #43 - FEATURE: Document Azure Active Directory Domain Services (AA

### DIFF
--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -572,6 +572,19 @@ flowchart TD
 > Entra External ID (external tenant). Do not confuse B2B guest users (workforce tenant) with
 > External ID (separate external tenant).
 
+## Hybrid Identity
+
+| Service | Purpose | Protocol | Use Case | Key Feature |
+| --- | --- | --- | --- | --- |
+| **Entra Connect** | Sync on-prem AD identities to Entra ID | LDAP → OAuth/OIDC | Hybrid orgs needing SSO across on-prem and cloud | Password hash sync, pass-through auth, federation |
+| **Entra Domain Services** | Managed domain services in Azure (no DCs to run) | LDAP / Kerberos / NTLM | Lift-and-shift apps requiring legacy auth in Azure | Fully managed, integrates with Entra ID tenant |
+| **Entra ID-only** | Cloud-native identity with no on-prem dependency | OAuth 2.0 / OIDC / SAML | Greenfield cloud workloads | No infrastructure to manage |
+
+> **Exam tip:** Choose Entra Domain Services when a lift-and-shift workload requires LDAP or
+> Kerberos authentication in Azure and you do not want to deploy and manage domain controllers.
+> Choose Entra Connect when the requirement is to sync existing on-premises Active Directory
+> accounts to the cloud for SSO or hybrid authentication.
+
 ---
 
 ## RBAC


### PR DESCRIPTION
## Summary

The IDENTITY & ACCESS section of the AZ-305 cheat sheet had no coverage of hybrid identity architecture — a gap that leaves candidates unprepared for exam scenarios involving on-premises AD integration, lift-and-shift workloads needing legacy auth, and the trade-offs between managed vs. self-managed domain services in Azure.

This PR adds a focused `## Hybrid Identity` sub-section that addresses the three identity topology choices examiners test: Entra Connect (sync), Entra Domain Services (managed LDAP/Kerberos), and Entra ID-only (cloud-native).

## Changes

**`docs/AZ-305_CheatSheet.md` — IDENTITY & ACCESS section**

- Added `## Hybrid Identity` sub-section after the existing Entra Identity Scenarios table (around line 572).
- Added a five-column comparison table (Service, Purpose, Protocol, Use Case, Key Feature) covering Entra Connect, Entra Domain Services, and Entra ID-only. Column layout conforms to AGENTS.md service-table templates.
- Added an exam-tip callout immediately after the table distinguishing when to choose Entra Domain Services (LDAP/Kerberos in Azure, no DC management) versus Entra Connect (sync on-prem AD for SSO/hybrid auth). Format follows the `> **Exam tip:**` convention defined in AGENTS.md.

No structural changes were made. All existing content is untouched.

## Testing

1. Render check — open `docs/AZ-305_CheatSheet.md` in VS Code with "Markdown Preview Mermaid Support" enabled and confirm the new table and exam-tip blockquote render correctly.
2. Lint — run the project linter and confirm zero new violations:
   ```
   npx markdownlint-cli2 "**/*.md"
   ```
3. Content review — verify the three rows cover Entra Connect, Entra Domain Services, and Entra ID-only, and that the exam-tip callout follows the table directly with no intervening content.

Closes #43