### PR TITLE
fix: resolve #44 - FEATURE: Add a Private Endpoint vs Service Endpoint decision

### DIFF
--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -118,6 +118,15 @@ flowchart TD
 > - Private Endpoint = PaaS resource gets a NIC in your VNet (true private)
 > - Service Endpoint = traffic stays on Azure backbone but PaaS still has public IP
 
+```mermaid
+flowchart TD
+    A[Secure PaaS service access?] --> B{Require private IP in VNet?}
+    B -- Yes --> PE[Private Endpoint]
+    B -- No --> C{Traffic must stay on Azure backbone?}
+    C -- Yes --> SE[Service Endpoint]
+    C -- No --> PUB[Public endpoint with firewall rules]
+```
+
 ---
 
 ## DNS


### PR DESCRIPTION
## Summary

The NETWORKING section's Virtual Networks topic noted the distinction between Private Endpoint and Service Endpoint in a blockquote, but offered no structured decision path. This distinction is a high-frequency exam distractor — candidates must select the correct option based on network isolation level and compliance requirements. A Mermaid flowchart enforces the decision logic precisely and consistently with other decision flows already present in the section.

## Changes

**`docs/AZ-305_CheatSheet.md`**

Added a `flowchart TD` Mermaid block immediately after the existing Private Endpoint vs Service Endpoint blockquote and before the DNS sub-section. The diagram walks the candidate through the two key branching questions:

1. Does the resource require a private IP within the VNet? → Private Endpoint
2. If not, must traffic stay on the Azure backbone? → Service Endpoint
3. Neither constraint? → Public endpoint with firewall rules

No tables, headings, or surrounding content were modified. The diagram follows the AGENTS.md Mermaid convention for decision flows (`flowchart TD`).

## Testing

1. Open `docs/AZ-305_CheatSheet.md` in VS Code with the "Markdown Preview Mermaid Support" extension and confirm the flowchart renders correctly with three terminal nodes (Private Endpoint, Service Endpoint, Public endpoint with firewall rules).
2. Run markdownlint locally:
   ```
   npx markdownlint-cli2 "**/*.md"
   ```
   Expect zero violations.
3. Confirm the CI `mermaid-check` and `markdownlint` jobs pass on the PR branch.

Closes #44