### PR TITLE
fix: resolve #45 - FEATURE: Add Azure Monitor Logs retention and cost trade-off

### DIFF
--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -416,6 +416,20 @@ graph TD
 
 ---
 
+## Log Analytics Retention & Cost Tiers
+
+| Tier | Type | Best For | Key Feature |
+| --- | --- | --- | --- |
+| **Analytics** | Interactive (30–730 days) | Active investigation, alerting | Full KQL, per-GB ingestion cost |
+| **Basic** | Interactive (8 days) | High-volume, low-value logs | Limited KQL, lower per-GB cost |
+| **Archive** | Cold (up to 12 years) | Compliance, audit, cold storage | Search jobs only, lowest per-GB cost |
+
+> **Exam tip:** Choose Basic tier for noisy, rarely queried logs (e.g. verbose diagnostics)
+> to reduce cost. Use Archive when retention beyond 730 days is required for compliance;
+> queries against archived data run as Search Jobs, not interactive KQL.
+
+---
+
 # COMPUTE
 
 ## Compute Options


### PR DESCRIPTION
## Summary

The MONITORING & OBSERVABILITY section of the AZ-305 cheat sheet documented Log Analytics Workspace retention only as a range ("30–730 days") with no detail on ingestion tiers or cost trade-offs. AZ-305 cost-optimisation scenarios require candidates to know when to route logs to Analytics vs Basic vs Archive tier — a gap that this PR closes.

## Changes

**docs/AZ-305_CheatSheet.md**

Added a new `## Log Analytics Retention & Cost Tiers` sub-section immediately before the COMPUTE section (after line 416).

- Introduced a four-column comparison table (Tier / Type / Best For / Key Feature) aligned with the AGENTS.md data/storage service column template.
- Covered all three tiers: Analytics (full KQL, 30–730 days), Basic (limited KQL, 8-day interactive, lower cost), and Archive (Search Jobs only, up to 12 years, lowest cost).
- Added an exam-tip callout below the table that highlights the two key decision points: Basic tier for high-volume noisy logs to reduce ingestion cost, and Archive tier when retention beyond 730 days is required for compliance.

## Testing

1. Render the Markdown locally to confirm the table and callout display correctly:
   - VS Code with "Markdown Preview Mermaid Support" extension, or
   - GitHub PR preview tab.
2. Run the linter to confirm no formatting violations:

```
npx markdownlint-cli2 "**/*.md"
```

Expected result: zero errors or warnings.

Closes #45