### PR TITLE
fix: resolve #47 - FEATURE: Add AZ-104 and AZ-900 coverage index so readers can

### DIFF
--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -21,6 +21,27 @@
 
 ---
 
+## Exam Track Index
+
+| Section | AZ-900 | AZ-104 | AZ-305 |
+| --- | --- | --- | --- |
+| Networking | Partial | Full | Full |
+| Security | — | Partial | Full |
+| Storage | Partial | Full | Full |
+| Monitoring & Observability | — | Partial | Full |
+| Compute | Partial | Full | Full |
+| Identity & Access | Partial | Full | Full |
+| High Availability & Disaster Recovery | — | Full | Full |
+| Governance | — | Partial | Full |
+| Messaging & Integration | — | — | Full |
+| Well-Architected Framework | — | — | Full |
+
+> **Exam tip:** AZ-900 rows marked Partial cover conceptual awareness only.
+> AZ-104 Full rows require administrator-level depth. AZ-305 covers all
+> sections with an architectural decision-making focus.
+
+---
+
 # NETWORKING
 
 > Also relevant for: **AZ-900** (foundational networking concepts) and **AZ-104**
@@ -187,6 +208,9 @@ graph LR
 
 # SECURITY
 
+> Also relevant for: **AZ-104** (Defender for Cloud policies, Key Vault
+> administration, security baselines).
+
 ## Microsoft Defender for Cloud
 
 | Plan | Covers | Key Feature |
@@ -281,6 +305,10 @@ graph LR
 
 # STORAGE
 
+> Also relevant for: **AZ-900** (storage account concepts, redundancy
+> options) and **AZ-104** (storage account management, access keys,
+> lifecycle policies, file shares).
+
 ## Storage Account Types
 
 | Type | Supported Services | Use Case |
@@ -372,6 +400,9 @@ graph TD
 
 # MONITORING & OBSERVABILITY
 
+> Also relevant for: **AZ-104** (Azure Monitor alerts, Log Analytics
+> workspace administration, diagnostic settings).
+
 ## Azure Monitor Ecosystem
 
 ```mermaid
@@ -440,6 +471,9 @@ graph TD
 ---
 
 # COMPUTE
+
+> Also relevant for: **AZ-900** (VM, App Service, and container concepts)
+> and **AZ-104** (VM deployment, VMSS, App Service plans, AKS node pools).
 
 ## Compute Options
 
@@ -690,6 +724,9 @@ graph TD
 
 # GOVERNANCE
 
+> Also relevant for: **AZ-104** (RBAC assignments, Policy definitions,
+> Management Groups, Blueprints administration).
+
 ## Management Hierarchy
 
 ```mermaid
@@ -770,6 +807,9 @@ graph TD
 
 # MESSAGING & INTEGRATION
 
+> Also relevant for: **AZ-104** (Service Bus namespace administration,
+> Event Grid subscriptions).
+
 ## Service Comparison
 
 | Service | Pattern | Ordering | Replay | Use Case |
@@ -832,6 +872,7 @@ flowchart TD
 
 > **Exam Focus:** Use WAF pillars to *justify* design decisions in
 > case-study questions — not just to name the correct service.
+> Relevant for **AZ-305** only; not assessed in AZ-900 or AZ-104.
 
 ## Five-Pillar Summary
 


### PR DESCRIPTION
## Summary

Readers studying for AZ-900 or AZ-104 had to manually cross-reference the README's exam-track table against `docs/AZ-305_CheatSheet.md` to find relevant sections. The cheat sheet itself offered no inline guidance. Some sections (NETWORKING, IDENTITY & ACCESS) already carried `> Also relevant for:` callouts, but SECURITY, STORAGE, MONITORING & OBSERVABILITY, COMPUTE, GOVERNANCE, MESSAGING & INTEGRATION, and WELL-ARCHITECTED FRAMEWORK had none, making coverage inconsistent.

This change surfaces the exam mapping directly inside the cheat sheet so readers can navigate by exam track without leaving the document.

## Changes

**Exam Track Index table** (inserted after the Table of Contents)
A new `## Exam Track Index` section lists all ten top-level sections against AZ-900, AZ-104, and AZ-305 coverage levels (Full / Partial / —). An exam tip callout immediately below explains what each coverage level means. This gives AZ-900 and AZ-104 candidates a single entry point before they dive into content.

**Per-section exam relevance callouts** (seven sections updated)
The `> Also relevant for:` blockquote — already present in NETWORKING and IDENTITY & ACCESS — was added to every section that lacked one:

- SECURITY — AZ-104 (Defender for Cloud, Key Vault, security baselines)
- STORAGE — AZ-900 and AZ-104 (storage accounts, redundancy, lifecycle policies)
- MONITORING & OBSERVABILITY — AZ-104 (Monitor alerts, Log Analytics, diagnostics)
- COMPUTE — AZ-900 and AZ-104 (VM/App Service concepts, VMSS, AKS)
- GOVERNANCE — AZ-104 (RBAC, Policy, Management Groups)
- MESSAGING & INTEGRATION — AZ-104 (Service Bus, Event Grid)
- WELL-ARCHITECTED FRAMEWORK — note added clarifying this section is AZ-305 only

All callouts mirror the existing style for consistency.

## Testing

1. Run the markdownlint check to confirm no formatting violations:

```
npx markdownlint-cli2 "**/*.md"
```

2. Open `docs/AZ-305_CheatSheet.md` on GitHub (or in VS Code with the Markdown Preview Mermaid Support extension) and verify:
   - The Exam Track Index table renders correctly after the Table of Contents.
   - The exam tip callout below the table renders as a blockquote.
   - Each of the seven updated sections shows the `> Also relevant for:` callout immediately below the section heading, before the first subsection.
   - No existing content was removed or reordered.

Closes #47