### PR TITLE
fix: resolve #54 - BUG: Deduplicate markdownlint config: .markdownlint.json and

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -3,6 +3,7 @@ config:
   MD025: false
   MD028: false
   MD033: false
+  MD040: false
   MD046: false
   MD055: false
   MD056: false

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,8 +1,0 @@
-{
-  "default": true,
-  "MD013": false,
-  "MD025": false,
-  "MD028": false,
-  "MD040": false,
-  "MD060": false
-}


### PR DESCRIPTION
## Summary

The repository carried two overlapping markdownlint configuration files — `.markdownlint.json` and `.markdownlint-cli2.yaml` — that suppressed partially different rule sets. This created a split-brain lint environment: `markdownlint-cli2` (used by CI) reads `.markdownlint-cli2.yaml`, while editors and contributors running `markdownlint` directly picked up `.markdownlint.json`. Rules like `MD040` were only suppressed in the JSON file, meaning CI could pass while local runs failed, or new contributors would see spurious failures that CI never caught.

## Changes

**.markdownlint-cli2.yaml** — Added the missing `MD040: false` entry to the `config:` block. This makes the CI config the single authoritative source of truth for all rule suppressions, including the one that was previously only in the JSON file.

**.markdownlint.json** — Deleted. The file is fully redundant now that `.markdownlint-cli2.yaml` covers the complete merged rule set. The VS Code markdownlint extension reads `.markdownlint-cli2.yaml`'s `config:` block natively, so no editor functionality is lost.

## Testing

Run the linter locally against all Markdown files and confirm a clean exit:

```bash
npx markdownlint-cli2 "**/*.md"
```

Expected: exit code 0, no rule violations reported. CI's `markdownlint` job should pass without any further changes.

Closes #54