### PR TITLE
fix: resolve #56 - FEATURE: Add a Compute decision flow diagram covering VM vs 

### DIFF
--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -489,6 +489,27 @@ graph TD
 | **Azure Batch** | HPC jobs | Large parallel compute jobs |
 | **Azure Spring Apps** | PaaS Java | Spring Boot microservices |
 
+## Compute Decision Flow
+
+```mermaid
+flowchart TD
+    A[New workload?] --> B{Need full OS / legacy lift-and-shift?}
+    B -- Yes --> VM[Azure VM / VMSS]
+    B -- No --> C{Containerised?}
+    C -- No --> D{Event-driven / serverless?}
+    D -- Yes --> AF[Azure Functions]
+    D -- No --> AS[App Service]
+    C -- Yes --> E{Need K8s API or custom controllers?}
+    E -- Yes --> AKS[AKS]
+    E -- No --> F{Single burst / no long-lived scale?}
+    F -- Yes --> ACI[ACI]
+    F -- No --> ACA[Azure Container Apps]
+```
+
+> **Exam tip:** Start with OS control (VM), then container vs. code, then
+> serverless vs. always-on. ACA is the default for containerised
+> microservices when you do not need full Kubernetes API access.
+
 ---
 
 ## App Service Plans (Tiers)


### PR DESCRIPTION
## Summary

The COMPUTE section of the AZ-305 cheat sheet had individual service tables and a container-specific ACI/ACA/AKS flowchart, but no top-level decision flow to guide readers from a workload requirement to the right compute tier. AZ-305 case-study questions frequently present a workload description and ask candidates to pick the appropriate compute service — this gap left a direct exam-style reasoning path undocumented.

This PR adds a single `flowchart TD` Mermaid diagram that covers the full compute landscape: VM/VMSS, App Service, Azure Functions, ACI, ACA, and AKS. It mirrors the decision logic an architect (and exam candidate) would apply: OS control first, then container vs. code, then serverless vs. always-on, then orchestration depth.

## Changes

**`docs/AZ-305_CheatSheet.md`**

- Added a new `## Compute Decision Flow` subsection immediately after the Compute Options table (~line 492), keeping proximity to the comparison data it extends.
- The `flowchart TD` diagram follows the AGENTS.md directive convention for decision flows (if/else trees).
- An exam tip callout is placed directly below the diagram per AGENTS.md format, highlighting the three-step decision heuristic and the ACA default for containerised microservices without full Kubernetes requirements.

No existing content was modified; this is a pure additive change.

## Testing

1. Mermaid rendering — open `docs/AZ-305_CheatSheet.md` on GitHub or in VS Code with the "Markdown Preview Mermaid Support" extension and confirm the diagram renders without errors.
2. Markdownlint — run `npx markdownlint-cli2 "**/*.md"` from the repository root and confirm it exits 0.
3. Mermaid validator — run `python validate_mermaid.py docs/AZ-305_CheatSheet.md` and confirm it passes.
4. Visual review — verify all six compute targets (VM/VMSS, App Service, Functions, ACI, ACA, AKS) appear as terminal nodes in the rendered diagram.

Closes #56