### PR TITLE
fix: resolve #57 - FEATURE: Document Azure Key Vault access models (RBAC vs Acc

### DIFF
--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -240,6 +240,20 @@ graph LR
 
 > Exam tip: Always use **Managed Identity** to access Key Vault — never store credentials in app config.
 
+## Key Vault Access Models
+
+| Service | Access Model | Audit | Granularity | Key Feature |
+| --- | --- | --- | --- | --- |
+| **Key Vault** | Vault Access Policies (legacy) | Per-vault log; no per-operation identity trail | Coarse — get/list/set apply to all secrets | Simple setup; max 1024 policies per vault |
+| **Key Vault** | Azure RBAC | Full Azure Activity Log + Entra audit trail | Fine-grained — role assignment per secret/key/cert | Entra-native; supports PIM, Conditional Access |
+
+> **Exam tip:** Choose Azure RBAC for Key Vault when the requirement mentions
+> Entra integration, Privileged Identity Management (PIM), per-resource
+> granularity, or migration away from legacy Access Policies.
+
+Use **Managed Identity** bound to an Azure RBAC role (e.g. Key Vault Secrets User)
+as the credential-free pattern — no secrets stored in application configuration.
+
 ---
 
 ## Encryption


### PR DESCRIPTION
## Summary

The SECURITY section of the AZ-305 cheat sheet contained only a bare assertion
("RBAC preferred") for the Key Vault access models decision — no comparison
table, no audit trail context, no migration guidance. Candidates encountering
exam scenarios that describe existing Key Vault deployments (legacy Access
Policies, PIM requirements, per-resource granularity) had no supporting
reasoning to anchor their decision.

This PR adds a dedicated `## Key Vault Access Models` subsection directly after
`## Azure Key Vault` in the SECURITY section, closing the content gap with
structured, exam-focused material.

## Changes

**docs/AZ-305_CheatSheet.md**

- Added `## Key Vault Access Models` subsection after the existing
  `## Azure Key Vault` subsection.
- Added a five-column comparison table (Service | Access Model | Audit |
  Granularity | Key Feature) covering Vault Access Policies (legacy) and
  Azure RBAC — columns follow the AGENTS.md template with Service and
  Key Feature always present.
- Added an exam-tip callout in the prescribed format identifying the
  decision signals: Entra integration, PIM, per-resource granularity,
  and migration away from legacy policies.
- Added a prose note on the Managed Identity + RBAC role pattern as the
  preferred credential-free access approach.

## Testing

1. Lint: `npx markdownlint-cli2 "**/*.md"` — must exit 0.
2. Mermaid validation: `python validate_mermaid.py` — must pass (no new
   diagrams were added, but existing diagrams must not regress).
3. Visual review: open `docs/AZ-305_CheatSheet.md` on GitHub and confirm
   the new table and exam-tip callout render correctly under the SECURITY
   section, immediately after `## Azure Key Vault`.

Closes #57