### PR TITLE
fix: resolve #81 - FEATURE: Add CONTRIBUTING.md with branch naming, commit styl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing
+
+Thank you for contributing to the Azure Cheat Sheets repository. This guide
+covers everything you need to make a clean, reviewable contribution.
+
+## Prerequisites
+
+You need `node` and `npm` on your PATH. No Python, ruff, or pytest is required
+— this is a documentation-only repository.
+
+## Local Setup
+
+Install the dev dependencies declared in `package.json`:
+
+```bash
+npm ci
+```
+
+This installs `markdownlint-cli2` (linter) and `@mermaid-js/mermaid-cli` (`mmdc`).
+
+## Running Checks Locally
+
+Run these commands from the repository root before opening a PR.
+
+Lint all Markdown files:
+
+```bash
+npx markdownlint-cli2 "**/*.md"
+```
+
+Validate a Mermaid diagram block (replace the input path as needed):
+
+```bash
+mmdc -i docs/AZ-305_CheatSheet.md -o /dev/null
+```
+
+Both commands must exit cleanly (exit code 0) before pushing.
+
+## Branch Naming
+
+| Prefix | Pattern | When to use |
+|--------|---------|-------------|
+| `feature/` | `feature/<section>-<topic>` | New content or new capability |
+| `fix/` | `fix/<section>-<topic>` | Correction to existing content |
+| `docs/` | `docs/<topic>` | Meta-documentation (README, CONTRIBUTING, etc.) |
+
+Examples: `feature/networking-private-endpoints`, `fix/storage-redundancy-table`,
+`docs/update-contributing-guide`.
+
+## Commit Message Style
+
+- Use the **imperative mood** in the subject line ("Add", "Fix", "Remove").
+- Limit the subject line to **72 characters**.
+- Leave one blank line between the subject and the body (if a body is needed).
+- Reference the related issue in the footer with `#<n>`.
+
+Example:
+
+```
+Add Azure Private Endpoint decision flowchart
+
+Closes #42
+```
+
+## Content Style Rules
+
+The rules below apply to all content in `docs/`.
+
+- Keep explanations concise and comparison-oriented.
+- Section headings: top-level domain names in ALL CAPS (`# NETWORKING`).
+  Sub-topics as `##`. Do not use Title Case for top-level section headings.
+- Prefer tables when comparing Azure services, tiers, or design options.
+  Use these column templates:
+
+  Networking / compute services:
+  | Service | Layer | Scope | Use Case | Key Feature |
+
+  Data / storage services:
+  | Service | Type | Best For | Key Feature |
+
+  Consistency columns (always present): Service, Key Feature.
+  Do not add free-form columns not in the template above.
+
+- Use short exam-tip callouts only when they clarify a likely decision point.
+  Format: place the callout immediately after the relevant table, using:
+
+  > **Exam tip:** Choose Azure Front Door when the requirement mentions
+  > global HTTP load balancing, WAF, or SSL offload at the edge.
+
+  Do not use plain blockquotes, bold sentences, or note/warning admonitions
+  for exam tips.
+
+- Use Mermaid diagrams for branching decision flows. Choose the directive by
+  purpose:
+
+  | Purpose                        | Directive       |
+  |--------------------------------|-----------------|
+  | Decision flows (if/else trees) | flowchart TD    |
+  | Hierarchy / ecosystem maps     | graph TD        |
+  | Connectivity / network paths   | graph LR        |
+
+  Example decision flow:
+
+  ```mermaid
+  flowchart TD
+      A[Need load balancing?] -->|Global HTTP| B[Azure Front Door]
+      A -->|Regional TCP/UDP| C[Azure Load Balancer]
+  ```
+
+- Avoid documenting features or claims that are not yet reflected in the
+  repository content.
+
+## PR Checklist
+
+Before requesting review, confirm each item:
+
+- [ ] `npx markdownlint-cli2 "**/*.md"` passes with no violations.
+- [ ] All Mermaid diagrams render correctly on GitHub.
+- [ ] Change is scoped to one improvement area.
+- [ ] README or CONTRIBUTING updated if any conventions changed.

--- a/README.md
+++ b/README.md
@@ -59,63 +59,8 @@ The cheat sheet includes Mermaid flowcharts for service-selection patterns.
 
 ## Contributing
 
-Contributions should keep the repository useful as a quick study and
-decision-reference tool.
-
-When editing or adding material:
-
-- Keep explanations concise and comparison-oriented.
-- Section headings: top-level domain names in ALL CAPS (`# NETWORKING`).
-  Sub-topics as `##`. Do not use Title Case for top-level section headings.
-- Prefer tables when comparing Azure services, tiers, or design options.
-  Use these column templates:
-
-  Networking / compute services:
-  | Service | Layer | Scope | Use Case | Key Feature |
-
-  Data / storage services:
-  | Service | Type | Best For | Key Feature |
-
-  Consistency columns (always present): Service, Key Feature.
-  Do not add free-form columns not in the template above.
-
-- Use short exam-tip callouts only when they clarify a likely decision point.
-  Format: place the callout immediately after the relevant table, using:
-
-  > **Exam tip:** Choose Azure Front Door when the requirement mentions
-  > global HTTP load balancing, WAF, or SSL offload at the edge.
-
-  Do not use plain blockquotes, bold sentences, or note/warning admonitions
-  for exam tips.
-
-- Use Mermaid diagrams for branching decision flows where a visual aid is more
-  useful than prose alone. Choose the variant by purpose:
-
-  | Purpose                        | Directive       |
-  |--------------------------------|-----------------|
-  | Decision flows (if/else trees) | flowchart TD    |
-  | Hierarchy / ecosystem maps     | graph TD        |
-  | Connectivity / network paths   | graph LR        |
-
-  Example decision flow:
-
-  ```mermaid
-  flowchart TD
-      A[Need load balancing?] -->|Global HTTP| B[Azure Front Door]
-      A -->|Regional TCP/UDP| C[Azure Load Balancer]
-  ```
-
-- Avoid documenting features or claims that are not yet reflected in the
-  repository content.
-
-For pull requests:
-
-- Keep changes scoped to one improvement area where possible.
-- Explain what section changed and why it improves the cheat sheet for readers.
-- Run `npx markdownlint-cli2 "**/*.md"` locally before opening a PR to
-  catch formatting violations before CI runs them.
-- Verify that Markdown formatting and Mermaid blocks still render cleanly on
-  GitHub.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming, commit style, local
+checks, content conventions, and the PR checklist.
 
 ## License
 


### PR DESCRIPTION
## Summary

Issue #81 identified that the repository lacked a dedicated contributor guide covering the Git workflow. The README's Contributing section documented content style rules but gave no guidance on branch naming, commit message conventions, how to run checks locally end-to-end, or what a PR checklist looks like. Contributors had to infer the workflow from the CI configuration — a friction point that leads to avoidable style violations and extra review round-trips.

## Changes

**CONTRIBUTING.md (new file)**
Created at the repository root as the authoritative contributor reference. Covers:
- Prerequisites (node/npm only — no Python tooling, matching the documentation-only scope of the repo)
- Local setup via `npm ci` to install markdownlint-cli2 and mmdc
- Exact commands to lint Markdown and validate Mermaid diagrams locally before pushing
- Branch naming conventions with a prefix table and concrete examples
- Commit message style (imperative mood, 72-char subject, issue reference footer)
- Content style rules migrated from README (table column templates, exam-tip callout format, Mermaid directive guide)
- PR checklist mirroring the CI jobs so contributors can self-verify before requesting review

**README.md (updated)**
Removed the detailed content style rules from the Contributing section and replaced them with a concise pointer to `CONTRIBUTING.md`. This eliminates duplication and gives the README a single source of truth to maintain.

## Testing

1. Run `npx markdownlint-cli2 "**/*.md"` from the repository root — expect zero violations on both `CONTRIBUTING.md` and `README.md`.
2. Open `CONTRIBUTING.md` on GitHub and verify all tables, code blocks, and Mermaid examples render correctly.
3. Confirm the README Contributing section now points to `CONTRIBUTING.md` and no longer duplicates the style rules.

Closes #81