### PR TITLE
fix: resolve #82 - BUG: Add lychee timeout and retry configuration to prevent t

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,5 +53,5 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         with:
-          args: --verbose --no-progress docs/**/*.md README.md
+          args: --verbose --no-progress --retry-wait-time 5 --max-retries 3 --timeout 30 docs/**/*.md README.md
           fail: true

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,6 @@
-# Domains that rate-limit or redirect aggressively — exclude to prevent false positives
+# Rate-limited / auth-gated — consistently returns 429 or redirects to login
 https://learn.microsoft.com
 https://portal.azure.com
+
+# Redirects aggressively to learn.microsoft.com; lychee follows the chain and hits the rate limit
+https://docs.microsoft.com


### PR DESCRIPTION
## Summary

The `link-check` job in CI was running lychee with default timeout and retry settings, making it vulnerable to transient 429/503 responses from external documentation hosts. This caused spurious CI failures unrelated to actual broken links, eroding confidence in the lint workflow.

This PR adds explicit retry and timeout flags to the lychee invocation and extends `.lycheeignore` to cover `docs.microsoft.com`, which aggressively redirects to `learn.microsoft.com` and triggers the same rate-limiting that already caused `learn.microsoft.com` to be excluded.

## Changes

**.github/workflows/lint.yml**
- Added `--max-retries 3`, `--retry-wait-time 5`, and `--timeout 30` to the lychee-action `args`.
- `--max-retries 3` gives transient failures three chances to recover before the job fails.
- `--retry-wait-time 5` adds a 5-second back-off between retries, reducing pressure on rate-limited hosts.
- `--timeout 30` sets an explicit per-request ceiling, preventing slow hosts from stalling the job indefinitely.

**.lycheeignore**
- Updated the header comment to be more precise: "Rate-limited / auth-gated".
- Added `https://docs.microsoft.com` with an inline comment explaining why it is excluded — it redirects aggressively to `learn.microsoft.com`, causing lychee to follow the chain and hit the same rate limit as the already-excluded `learn.microsoft.com`.

## Testing

1. Trigger the lint workflow on this branch: `gh workflow run lint.yml --ref <branch>` or open this PR and observe the `link-check` job.
2. Confirm the job passes on a branch where all links are known-good.
3. To simulate resilience manually: temporarily introduce a link to `docs.microsoft.com` and confirm it is skipped (not causing a failure) due to the `.lycheeignore` entry.
4. Confirm no genuine broken links are masked — all non-ignored links must still be checked and fail the job if unreachable.

Closes #82