### PR TITLE
fix: resolve #101 - BUG: Add pytest coverage for validate_mermaid main() happy-p

### DIFF
--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -1,4 +1,5 @@
 """Tests for issue #42 - error handling and exit-code reporting in validate_mermaid.py."""
+
 import sys
 from unittest.mock import patch
 
@@ -45,6 +46,7 @@ class TestValidateBlockTimeout:
 
     def test_validate_block_returns_false_on_timeout(self):
         import subprocess
+
         timeout_exc = subprocess.TimeoutExpired(cmd="mmdc", timeout=60)
         with patch("validate_mermaid.subprocess.run", side_effect=timeout_exc):
             result = validate_mermaid.validate_block(1, "graph TD\n  A --> B\n")
@@ -79,20 +81,23 @@ class TestMainFileNotFound:
 class TestExtractMermaidBlocks:
     """Parametrised tests for _extract_from_text() helper."""
 
-    @pytest.mark.parametrize("text,expected_count,expected_content", [
-        # single_block
-        ("```mermaid\ngraph TD\n  A --> B\n```", 1, "graph TD\n  A --> B\n"),
-        # multiple_blocks
-        ("```mermaid\ngraph TD\n  A-->B\n```\n\n```mermaid\ngraph LR\n  C-->D\n```", 2, None),
-        # no_blocks
-        ("# Heading\nSome text.", 0, None),
-        # non_mermaid_fence
-        ("```python\nprint('hi')\n```", 0, None),
-        # trailing_whitespace_fence
-        ("```mermaid   \ngraph TD\n  A-->B\n```", 1, None),
-        # crlf_line_endings
-        ("```mermaid\r\ngraph TD\r\n  A-->B\r\n```", 1, None),
-    ])
+    @pytest.mark.parametrize(
+        "text,expected_count,expected_content",
+        [
+            # single_block
+            ("```mermaid\ngraph TD\n  A --> B\n```", 1, "graph TD\n  A --> B\n"),
+            # multiple_blocks
+            ("```mermaid\ngraph TD\n  A-->B\n```\n\n```mermaid\ngraph LR\n  C-->D\n```", 2, None),
+            # no_blocks
+            ("# Heading\nSome text.", 0, None),
+            # non_mermaid_fence
+            ("```python\nprint('hi')\n```", 0, None),
+            # trailing_whitespace_fence
+            ("```mermaid   \ngraph TD\n  A-->B\n```", 1, None),
+            # crlf_line_endings
+            ("```mermaid\r\ngraph TD\r\n  A-->B\r\n```", 1, None),
+        ],
+    )
     def test_extract(self, text, expected_count, expected_content):
         result = validate_mermaid._extract_from_text(text)
         assert len(result) == expected_count
@@ -108,6 +113,7 @@ class TestPathlibRefactor:
         import inspect
 
         import validate_mermaid as vm
+
         src = inspect.getsource(vm.validate_block)
         assert "os.unlink" not in src, "validate_block must not use os.unlink"
         assert "os.path.exists" not in src, "validate_block must not use os.path.exists"
@@ -118,6 +124,7 @@ class TestPathlibRefactor:
         import inspect
 
         import validate_mermaid as vm
+
         src = inspect.getsource(vm.main)
         assert "os.path.isfile" not in src, "main() must not use os.path.isfile"
         assert ".is_file()" in src
@@ -128,10 +135,12 @@ class TestPathlibRefactor:
         import inspect
 
         import validate_mermaid as vm
+
         source = inspect.getsource(vm)
         tree = ast.parse(source)
         os_imports = [
-            node for node in ast.walk(tree)
+            node
+            for node in ast.walk(tree)
             if isinstance(node, (ast.Import, ast.ImportFrom))
             and any(
                 (alias.name == "os" if isinstance(node, ast.Import) else node.module == "os")
@@ -145,6 +154,7 @@ class TestPathlibRefactor:
         import inspect
 
         import validate_mermaid as vm
+
         src = inspect.getsource(vm.validate_block)
         assert '.replace(".mmd"' not in src, "must not use string.replace for suffix"
         assert "with_suffix" in src

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -148,3 +148,45 @@ class TestPathlibRefactor:
         src = inspect.getsource(vm.validate_block)
         assert '.replace(".mmd"' not in src, "must not use string.replace for suffix"
         assert "with_suffix" in src
+
+
+class TestMainHappyPath:
+    """main() exits 0 (no SystemExit) when all diagrams pass."""
+
+    def test_main_does_not_raise_when_all_diagrams_pass(self, capsys):
+        with (
+            patch("validate_mermaid.shutil.which", return_value="/usr/bin/mmdc"),
+            patch("validate_mermaid.sys.argv", ["validate_mermaid.py", "docs/AZ-305_CheatSheet.md"]),
+            patch("validate_mermaid.extract_mermaid_blocks", return_value=["graph TD\n  A --> B\n"]),
+            patch("validate_mermaid.validate_block", return_value=(True, "")),
+        ):
+            validate_mermaid.main()  # must not raise
+        captured = capsys.readouterr()
+        assert "All 1 diagram(s) passed" in captured.out
+
+
+class TestMainAggregateFail:
+    """main() exits 1 when one or more diagrams fail."""
+
+    def test_main_exits_1_when_diagram_fails(self):
+        with (
+            patch("validate_mermaid.shutil.which", return_value="/usr/bin/mmdc"),
+            patch("validate_mermaid.sys.argv", ["validate_mermaid.py", "docs/AZ-305_CheatSheet.md"]),
+            patch("validate_mermaid.extract_mermaid_blocks", return_value=["graph TD\n  A --> B\n"]),
+            patch("validate_mermaid.validate_block", return_value=(False, "syntax error")),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            validate_mermaid.main()
+        assert exc_info.value.code == 1
+
+    def test_main_prints_failure_summary(self, capsys):
+        with (
+            patch("validate_mermaid.shutil.which", return_value="/usr/bin/mmdc"),
+            patch("validate_mermaid.sys.argv", ["validate_mermaid.py", "docs/AZ-305_CheatSheet.md"]),
+            patch("validate_mermaid.extract_mermaid_blocks", return_value=["graph TD\n  A --> B\n"]),
+            patch("validate_mermaid.validate_block", return_value=(False, "syntax error")),
+            pytest.raises(SystemExit),
+        ):
+            validate_mermaid.main()
+        captured = capsys.readouterr()
+        assert "1 diagram(s) failed" in captured.out

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -150,14 +150,18 @@ class TestPathlibRefactor:
         assert "with_suffix" in src
 
 
+_DUMMY_ARGV = ["validate_mermaid.py", "docs/AZ-305_CheatSheet.md"]
+_ONE_BLOCK = ["graph TD\n  A --> B\n"]
+
+
 class TestMainHappyPath:
     """main() exits 0 (no SystemExit) when all diagrams pass."""
 
     def test_main_does_not_raise_when_all_diagrams_pass(self, capsys):
         with (
             patch("validate_mermaid.shutil.which", return_value="/usr/bin/mmdc"),
-            patch("validate_mermaid.sys.argv", ["validate_mermaid.py", "docs/AZ-305_CheatSheet.md"]),
-            patch("validate_mermaid.extract_mermaid_blocks", return_value=["graph TD\n  A --> B\n"]),
+            patch("validate_mermaid.sys.argv", _DUMMY_ARGV),
+            patch("validate_mermaid.extract_mermaid_blocks", return_value=_ONE_BLOCK),
             patch("validate_mermaid.validate_block", return_value=(True, "")),
         ):
             validate_mermaid.main()  # must not raise
@@ -171,8 +175,8 @@ class TestMainAggregateFail:
     def test_main_exits_1_when_diagram_fails(self):
         with (
             patch("validate_mermaid.shutil.which", return_value="/usr/bin/mmdc"),
-            patch("validate_mermaid.sys.argv", ["validate_mermaid.py", "docs/AZ-305_CheatSheet.md"]),
-            patch("validate_mermaid.extract_mermaid_blocks", return_value=["graph TD\n  A --> B\n"]),
+            patch("validate_mermaid.sys.argv", _DUMMY_ARGV),
+            patch("validate_mermaid.extract_mermaid_blocks", return_value=_ONE_BLOCK),
             patch("validate_mermaid.validate_block", return_value=(False, "syntax error")),
             pytest.raises(SystemExit) as exc_info,
         ):
@@ -182,8 +186,8 @@ class TestMainAggregateFail:
     def test_main_prints_failure_summary(self, capsys):
         with (
             patch("validate_mermaid.shutil.which", return_value="/usr/bin/mmdc"),
-            patch("validate_mermaid.sys.argv", ["validate_mermaid.py", "docs/AZ-305_CheatSheet.md"]),
-            patch("validate_mermaid.extract_mermaid_blocks", return_value=["graph TD\n  A --> B\n"]),
+            patch("validate_mermaid.sys.argv", _DUMMY_ARGV),
+            patch("validate_mermaid.extract_mermaid_blocks", return_value=_ONE_BLOCK),
             patch("validate_mermaid.validate_block", return_value=(False, "syntax error")),
             pytest.raises(SystemExit),
         ):


### PR DESCRIPTION
## Summary

Issue #101 identified two untested terminal branches in `scripts/validate_mermaid.py`: the `main()` happy-path (all diagrams pass, exit 0) and the aggregate-failure path (one or more diagrams fail, exit 1). Without coverage on these branches, a regression in the exit-code logic or the `failed` counter could silently pass CI. This PR adds the missing test classes and cleans up minor formatting inconsistencies in the existing test file.

## Changes

**tests/test_validate_mermaid.py**

- Added `TestMainHappyPath` — mocks `shutil.which`, `sys.argv`, `extract_mermaid_blocks`, and `validate_block` to simulate all diagrams passing. Asserts that `main()` completes without raising `SystemExit` (exit 0 path).
- Added `TestMainAggregateFail` — mocks one block returning `(False, 'syntax error')`. Asserts `SystemExit` is raised with code 1, covering the failure-aggregation branch.
- Reformatted the `@pytest.mark.parametrize` decorator in `TestExtractMermaidBlocks` to Black-style vertical layout — improves readability with no behavioural change.
- Added blank lines after inline `import` statements inside test methods — aligns with PEP 8 style and suppresses linter warnings.
- Reformatted a multi-line list comprehension in `TestPathlibRefactor` to one-element-per-line style — consistent with the rest of the file.

No production code was changed. The `validate_mermaid.py` script is untouched.

## Testing

Run the full test suite locally:

```bash
cd /path/to/azure-cheat-sheets
pytest tests/ -v
```

All existing tests must remain green. The two new classes (`TestMainHappyPath`, `TestMainAggregateFail`) must appear in the output and pass.

Optional — verify coverage improvement:

```bash
pytest tests/ --cov=scripts --cov-report=term-missing
```

The `main()` lines 80-95 in `scripts/validate_mermaid.py` should now show as covered.

Closes #101