### PR TITLE
fix: resolve #103 - FEATURE: CONTRIBUTING.md incorrectly states no Python toolin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,12 @@ covers everything you need to make a clean, reviewable contribution.
 
 ## Prerequisites
 
-You need `node` and `npm` on your PATH. No Python, ruff, or pytest is required
-— this is a documentation-only repository.
+You need `node` and `npm` on your PATH, and **Python 3.11+** with `ruff` and
+`pytest` for script validation and linting.
+
+```bash
+pip install ruff pytest
+```
 
 ## Local Setup
 
@@ -35,6 +39,19 @@ mmdc -i docs/AZ-305_CheatSheet.md -o /dev/null
 ```
 
 Both commands must exit cleanly (exit code 0) before pushing.
+
+Lint Python scripts:
+
+```bash
+ruff check scripts/
+ruff format --check scripts/
+```
+
+Run tests:
+
+```bash
+pytest tests/ -v
+```
 
 ## Branch Naming
 
@@ -115,6 +132,8 @@ The rules below apply to all content in `docs/`.
 Before requesting review, confirm each item:
 
 - [ ] `npx markdownlint-cli2 "**/*.md"` passes with no violations.
+- [ ] `ruff check scripts/` passes with no violations.
+- [ ] `pytest tests/ -v` passes with no failures.
 - [ ] All Mermaid diagrams render correctly on GitHub.
 - [ ] Change is scoped to one improvement area.
 - [ ] README or CONTRIBUTING updated if any conventions changed.


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` told contributors that no Python tooling was needed — a statement directly contradicted by the repository itself, which ships `scripts/validate_mermaid.py`, a `pyproject.toml` with ruff config, a `tests/` directory, and CI jobs (`python-lint`, `python-test`) that run on every push. Any contributor who followed the existing docs would push code that fails CI and have no explanation why.

## Changes

**Prerequisites section (lines 7-9)**
Replaced the incorrect "No Python, ruff, or pytest is required" statement with an accurate note that Python 3.11+, ruff, and pytest are required. Added a `pip install ruff pytest` snippet so contributors can get set up in one step.

**Running Checks Locally section**
Added two new command blocks after the existing Mermaid validation commands:
- `ruff check scripts/` and `ruff format --check scripts/` to lint Python scripts before pushing.
- `pytest tests/ -v` to run the test suite locally and catch failures before CI does.

**PR Checklist**
Added two new checklist items alongside the existing markdownlint step:
- `ruff check scripts/ passes with no violations`
- `pytest tests/ -v passes with no failures`

These mirror the CI jobs exactly, so passing the checklist locally guarantees a clean pipeline.

## Testing

1. Install the required tooling: `pip install ruff pytest`
2. Run `ruff check scripts/` — expect exit code 0, no violations.
3. Run `ruff format --check scripts/` — expect exit code 0.
4. Run `pytest tests/ -v` — expect all tests to pass.
5. Run `npx markdownlint-cli2 "**/*.md"` — no new violations introduced by this change.

Closes #103