### PR TITLE
fix: resolve #105 - FEATURE: Pin mermaid-cli to an exact version in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "azure-cheat-sheets",
       "version": "1.0.0",
       "devDependencies": {
-        "@mermaid-js/mermaid-cli": "^11.15.0"
+        "@mermaid-js/mermaid-cli": "11.15.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Azure architecture cheat sheets for AZ-305",
   "private": true,
   "devDependencies": {
-    "@mermaid-js/mermaid-cli": "^11.15.0"
+    "@mermaid-js/mermaid-cli": "11.15.0"
   }
 }


### PR DESCRIPTION
## Summary

`package.json` declared `@mermaid-js/mermaid-cli` with a caret range (`^11.15.0`), allowing any `11.x` minor or patch upgrade. While `npm ci` in CI respects `package-lock.json`, the lock file is not periodically refreshed — meaning a routine `npm install` during a lock file regeneration could silently pull in a newer `11.x` release. Mermaid CLI has a history of introducing breaking diagram syntax and Puppeteer peer-dependency changes across minor versions, making this a low-probability but high-surprise failure mode for CI.

Pinning to an exact version eliminates that drift and makes the dependency contract explicit.

## Changes

**`package.json`**
Changed `"@mermaid-js/mermaid-cli": "^11.15.0"` to `"@mermaid-js/mermaid-cli": "11.15.0"`.
Removes the caret, expressing an exact version requirement. This is the source-of-truth declaration.

**`package-lock.json`**
Updated to reflect the exact version pin.
The lock file entry in `devDependencies` is updated from `^11.15.0` to `11.15.0` to stay consistent with `package.json` and prevent any tooling from treating the range as still open.

## Testing

1. Verify the pin:
   ```
   grep mermaid-cli package.json
   ```
   Expected: `"@mermaid-js/mermaid-cli": "11.15.0"` — no `^` or `~` prefix.

2. Confirm the lock file is consistent:
   ```
   npm ci
   ```
   Should complete without warnings about version mismatches.

3. Confirm the `mermaid-check` CI job passes — it validates all Mermaid diagrams in `docs/AZ-305_CheatSheet.md` via `scripts/validate_mermaid.py`. A green run confirms the pinned version accepts all existing diagrams.

Closes #105