### PR TITLE
fix: resolve #106 - BUG: validate_mermaid.py does not validate the no-diagrams-f

### DIFF
--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -76,6 +76,12 @@ def main():
         sys.exit(1)
     blocks = extract_mermaid_blocks(md_path)
     print(f"Found {len(blocks)} mermaid diagram(s) in {md_path}")
+    if not blocks:
+        print(
+            "WARNING: no mermaid blocks found — check fence syntax.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     failed = 0
     for i, block in enumerate(blocks, start=1):

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -204,3 +204,28 @@ class TestMainAggregateFail:
             validate_mermaid.main()
         captured = capsys.readouterr()
         assert "1 diagram(s) failed" in captured.out
+
+
+class TestMainZeroBlocks:
+    """main() exits 2 with a stderr warning when no mermaid blocks are found."""
+
+    def test_main_exits_2_when_no_blocks_found(self):
+        with (
+            patch("validate_mermaid.shutil.which", return_value="/usr/bin/mmdc"),
+            patch("validate_mermaid.sys.argv", _DUMMY_ARGV),
+            patch("validate_mermaid.extract_mermaid_blocks", return_value=[]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            validate_mermaid.main()
+        assert exc_info.value.code == 2
+
+    def test_main_prints_warning_to_stderr_when_no_blocks_found(self, capsys):
+        with (
+            patch("validate_mermaid.shutil.which", return_value="/usr/bin/mmdc"),
+            patch("validate_mermaid.sys.argv", _DUMMY_ARGV),
+            patch("validate_mermaid.extract_mermaid_blocks", return_value=[]),
+            pytest.raises(SystemExit),
+        ):
+            validate_mermaid.main()
+        captured = capsys.readouterr()
+        assert "no mermaid blocks found" in captured.err


### PR DESCRIPTION
## Summary

`scripts/validate_mermaid.py` previously exited 0 when pointed at a Markdown file containing zero Mermaid blocks, printing `Found 0 mermaid diagram(s)` with no error. This created a silent false-green in CI: if a fence syntax change accidentally stopped the block-extraction regex from matching, the `mermaid-check` job would report success while all diagrams went unvalidated.

## Changes

**`scripts/validate_mermaid.py`**
Added a guard immediately after block extraction. When `blocks` is empty, the script now prints a warning to `stderr` and exits with code `2`. Exit code `2` was chosen (rather than `1`, which signals a diagram render failure) to distinguish the "nothing found" case from a genuine validation failure, making it easier to diagnose in CI logs.

**`tests/test_validate_mermaid.py`**
Added `TestMainZeroBlocks` with two focused tests:
- `test_main_exits_2_when_no_blocks_found` — asserts `SystemExit` code is `2`.
- `test_main_prints_warning_to_stderr_when_no_blocks_found` — asserts the warning message appears on `stderr`.

Both tests patch `extract_mermaid_blocks` to return `[]`, keeping them fast and isolated from the filesystem and `mmdc`.

## Testing

Run the new tests locally:

```bash
cd scripts
pytest ../tests/test_validate_mermaid.py::TestMainZeroBlocks -v
```

Verify the guard triggers manually:

```bash
echo "# No diagrams here" > /tmp/empty.md
python3 scripts/validate_mermaid.py /tmp/empty.md
echo "Exit code: $?"   # expect 2
```

Confirm CI still passes against the real cheat sheet — the `mermaid-check` job validates `docs/AZ-305_CheatSheet.md`, which contains multiple Mermaid blocks, so it will not trigger the new guard.

Closes #106