### PR TITLE
fix: resolve #109 - FEATURE: CONTRIBUTING.md mermaid validation command uses mmd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,10 +32,10 @@ Lint all Markdown files:
 npx markdownlint-cli2 "**/*.md"
 ```
 
-Validate a Mermaid diagram block (replace the input path as needed):
+Validate all Mermaid diagram blocks using the project script (`mmdc` must be on PATH — installed via `npm ci`):
 
 ```bash
-mmdc -i docs/AZ-305_CheatSheet.md -o /dev/null
+python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md
 ```
 
 Both commands must exit cleanly (exit code 0) before pushing.


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` instructed contributors to validate Mermaid diagrams using
`mmdc -i docs/AZ-305_CheatSheet.md -o /dev/null`. This diverged from the
canonical validation tool used in CI and documented in both `README.md` and
`AGENTS.md`: `python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md`.

The `mmdc` invocation skips zero-block detection and per-block reporting that
the script provides, meaning a contributor following the guide could miss
errors that CI would catch — a silent failure path on every contribution.

## Changes

**`CONTRIBUTING.md` — Running Checks Locally section**

- Replaced `mmdc -i docs/AZ-305_CheatSheet.md -o /dev/null` with
  `python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md`.
- Updated the prose label from "Validate a Mermaid diagram block" to
  "Validate all Mermaid diagram blocks using the project script" to
  accurately describe what the command does.
- Retained the note that `mmdc` must be on PATH (installed via `npm ci`),
  since the script delegates rendering to `mmdc` internally.

This makes the local workflow consistent with CI and eliminates the split
source of truth.

## Testing

1. Follow the updated instructions in `CONTRIBUTING.md`:
   ```
   npm ci
   python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md
   ```
   Confirm the script exits with code 0 and reports the number of validated
   blocks.
2. Run `npx markdownlint-cli2 "**/*.md"` — must exit cleanly.
3. Introduce a broken Mermaid block in `docs/AZ-305_CheatSheet.md`, rerun
   the script, and confirm it exits non-zero with a per-block error message.
   Revert after verifying.

Closes #109