### PR TITLE
fix: resolve #122 - BUG: Pin Python version consistently across CI jobs to avoid

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  PYTHON_VERSION: "3.11"
+
 jobs:
   markdownlint:
     runs-on: ubuntu-latest
@@ -20,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "20"
@@ -39,7 +45,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install ruff
         run: pip install ruff
       - name: Lint
@@ -53,7 +59,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install test deps
         run: pip install pytest pytest-cov
       - name: Run tests


### PR DESCRIPTION
## Summary

The `mermaid-check` CI job called `python3` without an explicit `setup-python` step, relying on whatever Python version GitHub's `ubuntu-latest` runner ships by default. As of 2024 runner updates that defaults to Python 3.12+, creating a silent divergence from the `python-lint` and `python-test` jobs which both pin `3.11`. This is a zero-cost hygiene fix that eliminates implicit runner dependency before Python 3.13 becomes the new default.

## Changes

- **Added `env.PYTHON_VERSION: "3.11"` at workflow level** — single source of truth for the Python version used across all three jobs. Updating one variable now updates all jobs atomically.
- **Added `setup-python` step to the `mermaid-check` job** — pins `validate_mermaid.py` execution to the same Python 3.11 environment as the lint and test jobs.
- **Replaced hardcoded `"3.11"` strings in `python-lint` and `python-test` jobs** — both jobs now reference `${{ env.PYTHON_VERSION }}` to stay consistent with the new workflow-level variable.

## Testing

CI will validate this automatically. To verify locally:

1. Review `.github/workflows/lint.yml` and confirm `env.PYTHON_VERSION: "3.11"` is declared at the top-level `env` block.
2. Confirm the `mermaid-check` job now contains a `setup-python` step referencing `${{ env.PYTHON_VERSION }}` before any `python3` invocation.
3. Confirm no remaining hardcoded `"3.11"` strings exist in `python-version:` fields — all three jobs should use the variable.
4. Push the branch and verify all three jobs (`mermaid-check`, `python-lint`, `python-test`) pass green on GitHub Actions.

Closes #122