### PR TITLE
fix: resolve #123 - BUG: Add integration test that validates all Mermaid diagram

### DIFF
--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -295,3 +295,16 @@ class TestMainZeroBlocks:
             validate_mermaid.main()
         captured = capsys.readouterr()
         assert "no mermaid blocks found" in captured.err
+
+
+class TestRealCheatSheet:
+    """Integration tests that read docs/AZ-305_CheatSheet.md from disk."""
+
+    def test_extracts_nonzero_blocks_from_real_cheat_sheet(self):
+        blocks = validate_mermaid.extract_mermaid_blocks("docs/AZ-305_CheatSheet.md")
+        assert len(blocks) > 0, "Expected at least one Mermaid block in the cheat sheet"
+
+    def test_all_blocks_are_non_empty_strings(self):
+        blocks = validate_mermaid.extract_mermaid_blocks("docs/AZ-305_CheatSheet.md")
+        for i, b in enumerate(blocks):
+            assert isinstance(b, str) and b.strip(), f"Block {i+1} is empty or not a string"


### PR DESCRIPTION
## Summary

All existing tests in `tests/test_validate_mermaid.py` mock `extract_mermaid_blocks` or operate on synthetic in-memory strings. This left a blind spot: a regression in the extraction regex — or a fence-format drift in the cheat sheet — would pass every unit test while silently breaking the real validation pipeline. This PR adds an integration-style test class that reads `docs/AZ-305_CheatSheet.md` directly from disk, closing that gap cheaply and without any external dependencies.

## Changes

**`tests/test_validate_mermaid.py`**
- Added `TestRealCheatSheet` class with two test methods that exercise the full extraction pipeline against the real cheat sheet file:
  - `test_extracts_nonzero_blocks_from_real_cheat_sheet` — asserts that at least one Mermaid block is found, catching any total extraction failure.
  - `test_all_blocks_are_non_empty_strings` — asserts every extracted block is a non-empty string, catching malformed or empty fence captures.
- No mocking is used; the tests rely solely on the live file and the production `extract_mermaid_blocks` implementation.

## Testing

Run the new tests without `mmdc` installed:

```bash
pytest tests/test_validate_mermaid.py::TestRealCheatSheet -v
```

Both tests should pass in milliseconds. They are also exercised by the existing `python-test` CI job — no workflow changes required. Coverage is unaffected as the new tests exercise already-covered production code paths.

Closes #123