### PR TITLE
fix: resolve #124 - FEATURE: Add dependabot configuration for pip/pyproject.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
       interval: weekly
     assignees:
       - DewaldOosthuizen
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    assignees:
+      - DewaldOosthuizen


### PR DESCRIPTION
## Summary

The `.github/dependabot.yml` file was only monitoring `github-actions` and `npm` ecosystems, leaving the Python dev dependencies (`pytest>=8.0`, `pytest-cov>=5.0`) declared in `pyproject.toml` untracked. Without a `pip` entry, Dependabot never generates automated PRs for patch or minor releases of the test toolchain, requiring manual version audits to stay current with security patches and compatibility fixes.

## Changes

**.github/dependabot.yml** — Added a `pip` ecosystem entry targeting the root directory (`/`) on a weekly schedule, assigned to `DewaldOosthuizen`. This mirrors the existing `github-actions` and `npm` entries in structure and cadence, and leverages Dependabot's native support for `pyproject.toml` (available since 2023). No other files required modification.

## Testing

Dependabot configuration changes cannot be unit-tested locally. Verification steps:

1. After merge, navigate to **Insights → Dependency graph → Dependabot** in the repository on GitHub.
2. Confirm a `pip` entry appears alongside the existing `github-actions` and `npm` entries.
3. On the next scheduled weekly run (or by triggering a manual check via the Dependabot UI), confirm Dependabot correctly detects `pyproject.toml` and evaluates `pytest` and `pytest-cov` for available updates.

No code changes were made — risk is effectively zero.

Closes #124