### PR TITLE
fix: resolve #126 - BUG: Harden validate_mermaid.py against shell-injection via 

### DIFF
--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -74,6 +74,11 @@ def main():
     if not Path(md_path).is_file():
         print(f"Error: file not found: {md_path}", file=sys.stderr)
         sys.exit(1)
+    repo_root = Path(__file__).parent.parent.resolve()
+    resolved = Path(md_path).resolve()
+    if not str(resolved).startswith(str(repo_root) + "/") and resolved != repo_root:
+        print(f"Error: path outside repository root: {md_path}", file=sys.stderr)
+        sys.exit(1)
     blocks = extract_mermaid_blocks(md_path)
     print(f"Found {len(blocks)} mermaid diagram(s) in {md_path}")
     if not blocks:

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -297,6 +297,45 @@ class TestMainZeroBlocks:
         assert "no mermaid blocks found" in captured.err
 
 
+class TestTraversalGuard:
+    """Tests for issue #126 - path traversal / shell-injection guard in main()."""
+
+    def test_main_exits_1_on_path_traversal(self, capsys):
+        """Path resolving outside repo root must be rejected with exit code 1."""
+        from pathlib import Path
+
+        with (
+            patch("validate_mermaid.shutil.which", return_value="/usr/bin/mmdc"),
+            patch("validate_mermaid.sys.argv", ["validate_mermaid.py", "/etc/passwd"]),
+            patch.object(Path, "is_file", return_value=True),
+            patch.object(Path, "resolve", return_value=Path("/etc/passwd")),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            validate_mermaid.main()
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "outside repository root" in captured.err
+
+    def test_main_does_not_exit_for_valid_path(self, capsys):
+        """A path within the repo root must pass the traversal guard."""
+        import scripts.validate_mermaid as vm_mod
+        from pathlib import Path
+
+        repo_root = Path(vm_mod.__file__).parent.parent.resolve()
+        valid_path = str(repo_root / "docs" / "AZ-305_CheatSheet.md")
+
+        with (
+            patch("validate_mermaid.shutil.which", return_value="/usr/bin/mmdc"),
+            patch("validate_mermaid.sys.argv", ["validate_mermaid.py", valid_path]),
+            patch.object(Path, "is_file", return_value=True),
+            patch("validate_mermaid.extract_mermaid_blocks", return_value=["graph TD\n  A --> B\n"]),
+            patch("validate_mermaid.validate_block", return_value=(True, "")),
+        ):
+            validate_mermaid.main()  # must not raise SystemExit due to traversal guard
+        captured = capsys.readouterr()
+        assert "outside repository root" not in captured.err
+
+
 class TestRealCheatSheet:
     """Integration tests that read docs/AZ-305_CheatSheet.md from disk."""
 

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -304,11 +304,18 @@ class TestTraversalGuard:
         """Path resolving outside repo root must be rejected with exit code 1."""
         from pathlib import Path
 
+        original_resolve = Path.resolve
+
+        def fake_resolve(self, strict=False):
+            if str(self) == "/etc/passwd":
+                return Path("/etc/passwd")
+            return original_resolve(self, strict=strict)
+
         with (
             patch("validate_mermaid.shutil.which", return_value="/usr/bin/mmdc"),
             patch("validate_mermaid.sys.argv", ["validate_mermaid.py", "/etc/passwd"]),
             patch.object(Path, "is_file", return_value=True),
-            patch.object(Path, "resolve", return_value=Path("/etc/passwd")),
+            patch.object(Path, "resolve", fake_resolve),
             pytest.raises(SystemExit) as exc_info,
         ):
             validate_mermaid.main()
@@ -318,8 +325,9 @@ class TestTraversalGuard:
 
     def test_main_does_not_exit_for_valid_path(self, capsys):
         """A path within the repo root must pass the traversal guard."""
-        import scripts.validate_mermaid as vm_mod
         from pathlib import Path
+
+        import scripts.validate_mermaid as vm_mod
 
         repo_root = Path(vm_mod.__file__).parent.parent.resolve()
         valid_path = str(repo_root / "docs" / "AZ-305_CheatSheet.md")
@@ -328,7 +336,10 @@ class TestTraversalGuard:
             patch("validate_mermaid.shutil.which", return_value="/usr/bin/mmdc"),
             patch("validate_mermaid.sys.argv", ["validate_mermaid.py", valid_path]),
             patch.object(Path, "is_file", return_value=True),
-            patch("validate_mermaid.extract_mermaid_blocks", return_value=["graph TD\n  A --> B\n"]),
+            patch(
+                "validate_mermaid.extract_mermaid_blocks",
+                return_value=["graph TD\n  A --> B\n"],
+            ),
             patch("validate_mermaid.validate_block", return_value=(True, "")),
         ):
             validate_mermaid.main()  # must not raise SystemExit due to traversal guard


### PR DESCRIPTION
## Summary

`validate_mermaid.py` accepted any user-supplied file path without verifying it
resided within the repository root. A crafted path such as `../../etc/passwd`
would be silently opened and its content passed to `mmdc`. While the current
usage is CI-local and the exploit surface is low, AGENTS.md explicitly invites
external contributors to run this script, making the pattern worth eliminating
before broader adoption.

## Changes

**scripts/validate_mermaid.py**
Added a path traversal guard in `main()` immediately after the existing
`is_file()` check. The fix resolves both the script's own location and the
caller-supplied path to absolute canonical forms, then asserts the resolved
path starts with the repository root. Any path resolving outside the root is
rejected with a descriptive message on stderr and exit code 1.

**tests/test_validate_mermaid.py**
Added `TestTraversalGuard` with two cases:
- `test_main_exits_1_on_path_traversal` — supplies `/etc/passwd` and asserts
  exit code 1 plus the `"outside repository root"` error on stderr.
- `test_main_does_not_exit_for_valid_path` — supplies a path under `docs/` and
  asserts the traversal guard does not fire, confirming the happy path is
  unaffected.

## Testing

Run the full test suite from the repository root:

```
pytest tests/test_validate_mermaid.py -v
```

All pre-existing tests must continue to pass. The two new tests in
`TestTraversalGuard` must both pass. To verify the guard manually:

```
python3 scripts/validate_mermaid.py /etc/passwd
# Expected: "Error: path outside repository root: /etc/passwd" on stderr, exit 1

python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md
# Expected: normal validation output, exit 0
```

Closes #126