### PR TITLE
fix: resolve #129 - FEATURE: Add GitHub Actions workflow for automated broken-li

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,25 +3,26 @@
 ## Project Overview
 
 This repository contains quick-reference study notes for Azure architecture
-decisions. It is aimed at candidates preparing for AZ-305: Designing Microsoft
-Azure Infrastructure Solutions. The focus is service selection, architectural
-trade-offs, and decision reasoning — not step-by-step walkthroughs, portal
-screenshots, or hands-on labs.
+decisions. It is aimed primarily at candidates preparing for AZ-305: Designing
+Microsoft Azure Infrastructure Solutions. The focus is service selection,
+architectural trade-offs, and decision reasoning — not step-by-step
+walkthroughs, portal screenshots, or hands-on labs.
 
 There is no application code, no build system, and no test suite. All
-meaningful content lives in a single Markdown file.
+meaningful content lives in the Markdown files under `docs/`.
 
 ## Repository Structure
 
 ```
-docs/AZ-305_CheatSheet.md   — the single main cheat sheet
+docs/AZ-305_CheatSheet.md   — AZ-305 architect-focused cheat sheet
+docs/AZ-104_CheatSheet.md   — AZ-104 administrator-focused cheat sheet
 scripts/validate_mermaid.py — CI script that validates Mermaid code blocks
 config/orchestrator.yml     — workspace-orchestrator pipeline config
 openspec/                   — openspec change workflow artefacts (proposals,
                               specs, impls, archive)
 ```
 
-The cheat sheet is organized into ten top-level sections:
+The cheat sheets are organized into ten top-level sections:
 
 1. Networking
 2. Security

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,5 +71,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         with:
-          args: --verbose --no-progress --retry-wait-time 5 --max-retries 3 --timeout 30 docs/**/*.md README.md
+          args: >-
+            --verbose --no-progress
+            --retry-wait-time 5 --max-retries 3 --timeout 30
+            docs/**/*.md README.md CONTRIBUTING.md AGENTS.md
           fail: true

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,12 @@
+# Rate-limited — returns 429 on automated scans
+https://learn.microsoft.com
+
+# Auth-gated — redirects to login page
+https://portal.azure.com
+
+# Aggressively redirecting — causes false-positive failures
+https://docs.microsoft.com
+
+# Repository-relative links unresolvable in GitHub Actions runner context
 ../../issues
 ../../pulls

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,6 +1,2 @@
-# Rate-limited / auth-gated — consistently returns 429 or redirects to login
-https://learn.microsoft.com
-https://portal.azure.com
-
-# Redirects aggressively to learn.microsoft.com; lychee follows the chain and hits the rate limit
-https://docs.microsoft.com
+../../issues
+../../pulls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ disrespectful, dismissive, or harmful will not be accepted.
 
 **Before you write a single line of content or code:**
 
-1. Browse the [GitHub Issues](../../issues) tab and find an issue you want to work on.
+1. Browse the [GitHub Issues](https://github.com/DewaldOosthuizen/azure-cheat-sheets/issues) tab and find an issue you want to work on.
 2. **Assign the issue to yourself** before starting any work.
    Go to the issue page → Assignees (right sidebar) → assign yourself.
    This signals to all other contributors that the issue is claimed.


### PR DESCRIPTION
## Summary

The `link-check` CI job previously only scanned `docs/**/*.md` and `README.md`, leaving `CONTRIBUTING.md` and `AGENTS.md` unvalidated. Links in `CONTRIBUTING.md` (GitHub Issues, PR tabs, section anchors) and external references in `AGENTS.md` were silently allowed to rot. This change closes that gap with a one-line YAML expansion and tightens up the `.lycheeignore` comments for clarity.

## Changes

**.github/workflows/lint.yml — link-check job args**
Expanded the lychee `args` field to include `CONTRIBUTING.md` and `AGENTS.md` alongside the existing `docs/**/*.md` and `README.md`. The args block is reformatted with a YAML block scalar (`>-`) for readability; the effective command is unchanged except for the two new file targets.

**.lycheeignore — relative-path exclusions and comment cleanup**
Added `../../issues` and `../../pulls` to ignore relative repository links that GitHub Actions cannot resolve from the runner filesystem. Reorganised the existing comment headers to separate rate-limited and auth-gated entries, which had been conflated.

**.github/copilot-instructions.md — minor accuracy fixes**
Updated the project overview and repository structure description to reflect that `AZ-104_CheatSheet.md` now exists alongside the AZ-305 sheet. The previous wording described a single Markdown file, which was no longer accurate.

## Testing

1. Push this branch and observe the `link-check` job in the Actions tab — it should complete without failures on `main`.
2. To verify the new files are picked up: introduce a deliberate broken link in `CONTRIBUTING.md` on a test branch and confirm the job fails as expected, then revert.
3. Confirm `.lycheeignore` suppresses false positives for `../../issues` and `../../pulls` — these are structural relative links that cannot be resolved in the CI runner context and are intentionally excluded.

Closes #129