### PR TITLE
fix: resolve #135 - BUG: Add pre-commit config to enforce markdownlint and ruff 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.17.2
+    hooks:
+      - id: markdownlint-cli2
+        files: ^(docs/.*\.md|README\.md|AGENTS\.md)$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,12 +90,24 @@ npm ci
 
 This installs `markdownlint-cli2` (linter) and `@mermaid-js/mermaid-cli` (`mmdc`).
 
+Install the pre-commit hooks (one-time setup per clone):
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The hooks run automatically on `git commit` and enforce the same ruff and
+markdownlint checks that CI applies on push.
+
 ---
 
 ## 6. Running Checks Locally
 
-Run these commands from the repository root before pushing. CI runs the same
-checks and a failing PR will not be reviewed.
+Run these commands from the repository root before pushing, or rely on the
+pre-commit hooks installed in [Section 5](#5-development-setup) to run them
+automatically on each commit. CI applies the same checks and a failing PR will
+not be reviewed.
 
 Lint all Markdown files:
 


### PR DESCRIPTION
## Summary

CI already enforces `ruff check`, `ruff format`, and `markdownlint-cli2` on every push and PR. Without a local pre-commit configuration, contributors only discover lint failures after pushing — adding noise to the CI history and slowing the feedback loop. This PR introduces `.pre-commit-config.yaml` so those same checks run automatically on `git commit`, surfacing violations in seconds before they ever reach CI.

## Changes

**.pre-commit-config.yaml** (new file)
Defines two hook sources that mirror what CI runs:
- `astral-sh/ruff-pre-commit` (v0.9.0) — runs `ruff` with `--fix` and `ruff-format` on Python files.
- `DavidAnson/markdownlint-cli2` (v0.17.2) — runs the Markdown linter scoped to `docs/`, `README.md`, and `AGENTS.md`, matching the CI file pattern.

**CONTRIBUTING.md** (updated)
- Added a one-time setup block in Section 5 (Development Setup) with `pip install pre-commit` and `pre-commit install` instructions.
- Updated the Section 6 (Running Checks Locally) preamble to note that the pre-commit hooks can replace the manual commands, keeping the manual steps as a fallback for contributors who prefer not to use pre-commit.

CI workflows are untouched — pre-commit is a developer convenience layer, not a CI replacement.

## Testing

1. Clone the branch and run the one-time setup:
   ```bash
   pip install pre-commit
   pre-commit install
   ```
2. Verify all hooks pass on the current codebase:
   ```bash
   pre-commit run --all-files
   ```
   Expected: all hooks exit 0 with no violations.
3. Introduce a deliberate Markdown lint violation (e.g. a trailing space) and attempt `git commit` — the hook should block the commit and print the violation.
4. Confirm CI passes without modification — no workflow files were changed.

Closes #135