### PR TITLE
fix: resolve #133 - BUG: Add integration test that runs validate_mermaid.py agai

### DIFF
--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -1,5 +1,6 @@
 """Tests for issue #42 - error handling and exit-code reporting in validate_mermaid.py."""
 
+import shutil
 import sys
 from unittest.mock import patch
 
@@ -331,3 +332,15 @@ class TestRealCheatSheet:
         blocks = validate_mermaid.extract_mermaid_blocks("docs/AZ-305_CheatSheet.md")
         for i, b in enumerate(blocks):
             assert isinstance(b, str) and b.strip(), f"Block {i + 1} is empty or not a string"
+
+
+@pytest.mark.skipif(shutil.which("mmdc") is None, reason="mmdc not installed")
+class TestRealCheatSheetIntegration:
+    """Integration tests that invoke validate_block against the real cheat sheet."""
+
+    def test_all_diagrams_pass(self):
+        blocks = validate_mermaid.extract_mermaid_blocks("docs/AZ-305_CheatSheet.md")
+        assert len(blocks) > 0, "Expected at least one Mermaid block in the cheat sheet"
+        for i, block in enumerate(blocks):
+            ok, err = validate_mermaid.validate_block(i, block)
+            assert ok, f"Diagram {i + 1} failed: {err}"


### PR DESCRIPTION
## Summary

`TestRealCheatSheet` in `tests/test_validate_mermaid.py` verified that Mermaid blocks could be extracted from the real cheat sheet, but never called `validate_block` — meaning a malformed diagram was invisible to the `python-test` job and would only be caught by the separate `mermaid-check` CI job. This left a gap in test coverage: the coverage report did not reflect that the primary deliverable (`validate_block`) had been exercised against the actual source file.

## Changes

**`tests/test_validate_mermaid.py`**

Added a new `TestRealCheatSheetIntegration` class decorated with `@pytest.mark.skipif(shutil.which("mmdc") is None, reason="mmdc not installed")`. The single test method `test_all_diagrams_pass` extracts every Mermaid block from `docs/AZ-305_CheatSheet.md` and calls `validate_block` on each one, asserting both that at least one block exists and that every block passes without error.

- The skip guard ensures the test is a no-op in environments without `mmdc`, so local runs and lightweight CI stages are unaffected.
- In CI, `mmdc` is already installed by `npm ci` in the `mermaid-check` job; the same toolchain makes this test runnable in the `python-test` job once `mmdc` is on PATH there.

## Testing

**Automated — with `mmdc` installed:**
```
pytest tests/test_validate_mermaid.py -v -k TestRealCheatSheetIntegration
```
All 17 diagrams in `docs/AZ-305_CheatSheet.md` should pass. Any malformed block will produce a named failure identifying the diagram number and the error message returned by `mmdc`.

**Automated — without `mmdc`:**
```
pytest tests/test_validate_mermaid.py -v -k TestRealCheatSheetIntegration
```
The entire class is skipped gracefully (`SKIPPED [1] mmdc not installed`).

**Coverage gate:** Run `pytest --cov` to confirm the 90 % threshold is maintained.

Closes #133