### PR TITLE
fix: resolve #134 - FEATURE: Expand cheat sheet with AZ-500 Security Engineer co

### DIFF
--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -44,6 +44,24 @@
 
 ---
 
+## AZ-500 Quick Index
+
+Key sub-topics for AZ-500 Security Engineer candidates:
+
+- [Microsoft Defender for Cloud](#microsoft-defender-for-cloud)
+- [Azure Key Vault & Access Models](#azure-key-vault)
+- [Encryption](#encryption)
+- [Policy & Compliance](#policy--compliance)
+- [Authentication & Password Security — PIM, Conditional Access, Identity Protection](#authentication--password-security)
+- [Microsoft Sentinel](#microsoft-sentinel)
+- [Network Security — NSGs, Azure Firewall, DDoS](#network-security)
+- [RBAC](#rbac)
+- [PIM Key Concepts](#pim-key-concepts)
+- [Log Analytics & Diagnostic Settings](#diagnostic-settings)
+- [Governance — Management Hierarchy, Locks](#management-hierarchy)
+
+---
+
 # NETWORKING
 
 > Also relevant for: **AZ-900** (foundational networking concepts) and **AZ-104**
@@ -216,6 +234,12 @@ flowchart TD
 
 ---
 
+> **Exam tip (AZ-500):** For AZ-500, know the layered network security model:
+> NSG = layer-4 allow/deny on subnet or NIC; Azure Firewall = stateful L3-L7
+> with FQDN rules and threat intelligence; NVA = third-party deep inspection.
+> DDoS Protection Standard (not Basic) is required when the question mentions
+> SLA-backed mitigation, telemetry, or cost protection for volumetric attacks.
+
 ## Content Delivery (CDN)
 
 | Service | Layer | Scope | Use Case | Key Feature |
@@ -266,6 +290,12 @@ graph LR
 | **Defender CSPM** | Cloud posture | Attack path analysis, governance |
 
 ---
+
+> **Exam tip (AZ-500):** Microsoft Defender for Cloud is the current name —
+> "Security Center" and "Azure Defender" are legacy names that may appear
+> in older questions. JIT VM Access (under Defender for Servers) locks down
+> management ports and opens them only on approved request; choose it when
+> the requirement mentions reducing the attack surface on VM management ports.
 
 ## Azure Key Vault
 
@@ -357,6 +387,11 @@ as the credential-free pattern — no secrets stored in application configuratio
 > Sentinel = SIEM + SOAR. Defender for Cloud = CSPM + workload protection. They integrate but serve different roles.
 
 ---
+
+> **Exam tip (AZ-500):** Sentinel is a cloud-native SIEM + SOAR; Defender for
+> Cloud is CSPM + workload protection. AZ-500 questions that mention "incident
+> response automation" or "playbook" point to Sentinel. Questions that mention
+> "secure score" or "recommendations" point to Defender for Cloud.
 
 # STORAGE
 
@@ -518,6 +553,11 @@ graph TD
 - Categories: AllMetrics, Audit, Operational, etc.
 
 ---
+
+> **Exam tip (AZ-500):** Diagnostic Settings are the bridge between Azure
+> resources and Microsoft Sentinel. Route Activity Logs, Entra audit logs, and
+> resource diagnostic logs to a Log Analytics Workspace that Sentinel reads from.
+> Without Diagnostic Settings configured, Sentinel data connectors receive no data.
 
 ## Log Analytics Retention & Cost Tiers
 
@@ -789,6 +829,12 @@ flowchart TD
 
 ---
 
+> **Exam tip (AZ-500):** AZ-500 tests PIM activation depth — know the difference
+> between eligible (requires activation) and active (always on) role assignments.
+> Access Reviews are the recurring compliance mechanism; PIM is the just-in-time
+> access mechanism. Conditional Access is the Zero Trust policy enforcement point
+> — combine it with Identity Protection risk signals to auto-block risky sign-ins.
+
 # HIGH AVAILABILITY & DISASTER RECOVERY
 
 > Also relevant for: **AZ-104** (Availability Sets, Availability Zones, Backup,
@@ -922,6 +968,11 @@ graph TD
 > Source: [Azure Lock Resources — Microsoft Learn](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources)
 
 ---
+
+> **Exam tip (AZ-500):** Azure Policy is the primary compliance enforcement tool
+> in AZ-500 — know Deny (blocks creation), Audit (flags without blocking), and
+> DeployIfNotExists (auto-remediates). Resource Locks (ReadOnly / Delete) protect
+> against accidental change or deletion but do not enforce configuration compliance.
 
 # MESSAGING & INTEGRATION
 

--- a/tests/test_issue_134_az500.py
+++ b/tests/test_issue_134_az500.py
@@ -1,0 +1,28 @@
+"""Tests for issue #134 - FEATURE: Expand cheat sheet with AZ-500 Security Engineer content."""
+
+from pathlib import Path
+
+CHEAT_SHEET = Path("docs/AZ-305_CheatSheet.md")
+
+
+def _content():
+    return CHEAT_SHEET.read_text(encoding="utf-8")
+
+
+class TestAZ500QuickIndex:
+    """Verify AZ-500 Quick Index section exists."""
+
+    def test_az500_quick_index_section_exists(self):
+        assert "## AZ-500 Quick Index" in _content(), (
+            "Expected '## AZ-500 Quick Index' section in docs/AZ-305_CheatSheet.md"
+        )
+
+
+class TestAZ500ExamTips:
+    """Verify at least 5 AZ-500 exam tip callouts exist."""
+
+    def test_at_least_five_az500_exam_tips(self):
+        count = _content().count("> **Exam tip (AZ-500):**")
+        assert count >= 5, (
+            f"Expected at least 5 occurrences of '> **Exam tip (AZ-500):**', found {count}"
+        )


### PR DESCRIPTION
## Summary

Issue #134 identified that while `README.md` and `AGENTS.md` both declare AZ-500 overlap across the Security, Identity & Access, Networking, Monitoring & Observability, and Governance sections, the cheat sheet contained no AZ-500-specific guidance. A candidate preparing for AZ-500 had to mentally filter AZ-305 content with no signposting. This PR adds targeted AZ-500 exam tips and a navigation index so the repository serves both exam audiences without duplicating content.

## Changes

**`docs/AZ-305_CheatSheet.md`**

- Added an `## AZ-500 Quick Index` section near the top of the document, providing deep-links to every section relevant to AZ-500 Security Engineer candidates. Candidates can now jump directly to the sub-topics the exam tests rather than reading the full document linearly.
- Added 6 AZ-500-specific `> **Exam tip (AZ-500):**` callouts placed immediately after the relevant tables, covering:
  - **Networking / Network Security** — layered security model (NSG vs. Azure Firewall vs. NVA), DDoS Protection Standard requirements.
  - **Security / Defender for Cloud** — legacy naming (Security Center, Azure Defender), JIT VM Access for attack surface reduction.
  - **Security / Sentinel** — SIEM+SOAR vs. CSPM distinction; playbook vs. secure score decision triggers.
  - **Monitoring & Observability / Diagnostic Settings** — Diagnostic Settings as the required bridge to Sentinel data connectors.
  - **Identity & Access / PIM** — eligible vs. active assignments, Access Reviews vs. PIM, Conditional Access + Identity Protection integration.
  - **Governance / Policy** — Deny vs. Audit vs. DeployIfNotExists effects, Resource Locks.

Each callout targets a decision point that diverges in emphasis between AZ-305 and AZ-500, not just restating existing content.

**`tests/test_issue_134_az500.py`**

- Added 28-line regression test suite that asserts the AZ-500 Quick Index is present and that each of the 5+ required exam-tip callouts exists in the cheat sheet. These tests run in CI to prevent accidental removal of AZ-500 coverage during future edits.

## Testing

Automated checks:
```
npx markdownlint-cli2 "**/*.md"
python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md
pytest tests/test_issue_134_az500.py -v
```

Manual verification:
1. Open `docs/AZ-305_CheatSheet.md` on GitHub and confirm the AZ-500 Quick Index renders with working anchor links.
2. Search the file for `Exam tip (AZ-500)` — at least 6 callouts should appear across the Security, Networking, Monitoring, Identity, and Governance sections.
3. Confirm no existing AZ-305 exam tips were altered or removed.

Closes #134