### PR TITLE
fix: resolve #137 - BUG: Replace hardcoded /tmp/puppeteer-config.json path with 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
 
   mermaid-check:
     runs-on: ubuntu-latest
+    env:
+      PUPPETEER_CONFIG_FILE: /tmp/puppeteer-config.json
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -2,6 +2,7 @@
 """Validate all fenced mermaid blocks in a Markdown file using mmdc."""
 
 import argparse
+import os
 import re
 import shutil
 import subprocess
@@ -9,7 +10,8 @@ import sys
 import tempfile
 from pathlib import Path
 
-PUPPETEER_CONFIG = Path("/tmp/puppeteer-config.json")
+_default_puppeteer_config = Path(tempfile.gettempdir()) / "puppeteer-config.json"
+PUPPETEER_CONFIG = Path(os.environ.get("PUPPETEER_CONFIG_FILE", str(_default_puppeteer_config)))
 
 
 def _repo_root() -> Path:

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -119,8 +119,8 @@ class TestPathlibRefactor:
         assert "os.path.isfile" not in src, "run() must not use os.path.isfile"
         assert ".is_file()" in src
 
-    def test_import_os_removed(self):
-        """The script must not import os after the refactor."""
+    def test_import_os_present(self):
+        """The script must import os (needed for os.environ.get in PUPPETEER_CONFIG)."""
         import ast
         import inspect
 
@@ -137,7 +137,7 @@ class TestPathlibRefactor:
                 for alias in node.names
             )
         ]
-        assert not os_imports, "import os must be removed after pathlib refactor"
+        assert os_imports, "import os must be present for env-var-driven PUPPETEER_CONFIG"
 
     def test_out_path_derived_with_suffix(self):
         """SVG path must be derived with Path.with_suffix, not string.replace."""


### PR DESCRIPTION
## Summary

`scripts/validate_mermaid.py` hard-coded `PUPPETEER_CONFIG` to `/tmp/puppeteer-config.json`. This path is fragile — it breaks silently on Windows, macOS with sandboxed temp dirs, or any CI runner that deviates from the standard temp location. This fix makes the path portable by deriving it from an environment variable (`PUPPETEER_CONFIG_FILE`) with a `tempfile.gettempdir()`-based default.

## Changes

**`scripts/validate_mermaid.py`**
Replaced the hard-coded `Path("/tmp/puppeteer-config.json")` constant with a two-liner that reads `PUPPETEER_CONFIG_FILE` from the environment, falling back to `tempfile.gettempdir() / "puppeteer-config.json"`. The `os` module import was added to support `os.environ.get`.

**`.github/workflows/lint.yml`**
Added a job-level `env` block to the `mermaid-check` job that sets `PUPPETEER_CONFIG_FILE: /tmp/puppeteer-config.json`. This keeps CI behaviour deterministic and identical to the previous hard-coded value, with no functional regression.

**`tests/test_validate_mermaid.py`**
Inverted `test_import_os_removed` → `test_import_os_present`. The previous test asserted that `import os` was absent (a leftover guard from an earlier pathlib refactor). Now that `os` is legitimately required for `os.environ.get`, the assertion is flipped to confirm the import is present.

## Testing

Run the full test suite locally:

```bash
python -m pytest tests/test_validate_mermaid.py -v
```

Verify the env-var override works end-to-end:

```bash
export PUPPETEER_CONFIG_FILE=/tmp/my-custom-puppeteer.json
python scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md
```

Confirm linting is clean:

```bash
ruff check scripts/validate_mermaid.py
```

CI will exercise the `mermaid-check` job with the new `PUPPETEER_CONFIG_FILE` env var set at the job level.

Closes #137