### PR TITLE
fix: resolve #138 - FEATURE: Add Python version matrix (3.11, 3.12, 3.13) to the

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,11 +57,15 @@ jobs:
 
   python-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
       - name: Install test deps
         run: pip install pytest pytest-cov
       - name: Run tests


### PR DESCRIPTION
## Summary

The `python-test` CI job in `.github/workflows/lint.yml` previously tested `validate_mermaid.py` against a single Python version (3.11). This means regressions introduced by newer Python minor versions — such as the `sys.path` changes in 3.12 or `subprocess`/`tempfile` semantic shifts — would go undetected until a contributor hit them locally. Adding a version matrix is low-cost given the script's simplicity and provides an early compatibility signal across the supported interpreter range.

## Changes

- `.github/workflows/lint.yml` — Added a `strategy.matrix` block to the `python-test` job with `python-version: ["3.11", "3.12", "3.13"]` and set `fail-fast: false` so all variants run to completion even if one fails. The `actions/setup-python` step now reads `matrix.python-version` instead of the static `env.PYTHON_VERSION`, making each matrix leg use its own interpreter.

## Testing

CI will run the full `python-test` job three times in parallel — once per matrix variant. Verify by:

1. Inspecting the Actions run for this PR and confirming three `python-test` matrix legs appear (3.11, 3.12, 3.13).
2. Confirming all three legs pass the pytest suite with the 90% coverage threshold met.
3. Optionally, run locally against any of the three versions:
   ```
   python3 -m pip install pytest pytest-cov
   python3 -m pytest tests/ --cov=scripts --cov-fail-under=90
   ```

Closes #138