### PR TITLE
fix: resolve #139 - BUG: Add error handling for mmdc producing an empty SVG outp

### DIFF
--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -52,7 +52,14 @@ def validate_block(index, diagram_src):
             text=True,
             timeout=60,
         )
-        return result.returncode == 0, result.stderr
+        if result.returncode == 0:
+            if not out_path.exists() or out_path.stat().st_size < 100:
+                return (
+                    False,
+                    "mmdc produced an empty/degenerate SVG (possible silent render failure)",
+                )
+            return True, result.stderr
+        return False, result.stderr
     except subprocess.TimeoutExpired:
         return (False, "mmdc timed out after 60 s")
     except FileNotFoundError:

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -173,6 +173,7 @@ class TestValidateBlockPuppeteerConfig:
         def _write_svg_and_succeed(cmd, **kwargs):
             input_flag = cmd.index("--input")
             from pathlib import Path as _Path
+
             out_file = _Path(cmd[input_flag + 1]).with_suffix(".svg")
             out_file.write_bytes(b"<svg>" + b"x" * 200 + b"</svg>")
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
@@ -197,6 +198,7 @@ class TestValidateBlockPuppeteerConfig:
         def _write_svg_and_succeed(cmd, **kwargs):
             input_flag = cmd.index("--input")
             from pathlib import Path as _Path
+
             out_file = _Path(cmd[input_flag + 1]).with_suffix(".svg")
             out_file.write_bytes(b"<svg>" + b"x" * 200 + b"</svg>")
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
@@ -347,6 +349,7 @@ class TestValidateBlockDegenerateSvg:
             tmp_file = cmd[input_flag + 1]
             out_file = str(tmp_file).replace(".mmd", ".svg")
             from pathlib import Path as _Path
+
             _Path(out_file).write_bytes(b"")
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -320,6 +320,32 @@ class TestTraversalGuard:
         assert "outside repository root" not in captured.err
 
 
+class TestValidateBlockDegenerateSvg:
+    """Tests for degenerate (empty/missing) SVG guard in validate_block()."""
+
+    def test_validate_block_returns_false_on_degenerate_svg(self, tmp_path):
+        import subprocess
+
+        def _write_empty_svg_and_succeed(cmd, **kwargs):
+            # Derive out_path the same way validate_block does
+            import re as _re
+            input_flag = cmd.index("--input")
+            tmp_file = cmd[input_flag + 1]
+            out_file = str(tmp_file).replace(".mmd", ".svg")
+            from pathlib import Path as _Path
+            _Path(out_file).write_bytes(b"")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        with (
+            patch("validate_mermaid.PUPPETEER_CONFIG") as mock_cfg,
+            patch("validate_mermaid.subprocess.run", side_effect=_write_empty_svg_and_succeed),
+        ):
+            mock_cfg.exists.return_value = False
+            ok, msg = validate_mermaid.validate_block(1, "graph TD\n  A --> B\n")
+        assert ok is False
+        assert msg == "mmdc produced an empty/degenerate SVG (possible silent render failure)"
+
+
 class TestRealCheatSheet:
     """Integration tests that read docs/AZ-305_CheatSheet.md from disk."""
 

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -170,10 +170,19 @@ class TestValidateBlockPuppeteerConfig:
     def test_validate_block_appends_puppeteer_config_when_present(self):
         import subprocess
 
-        success_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        def _write_svg_and_succeed(cmd, **kwargs):
+            input_flag = cmd.index("--input")
+            from pathlib import Path as _Path
+            out_file = _Path(cmd[input_flag + 1]).with_suffix(".svg")
+            out_file.write_bytes(b"<svg>" + b"x" * 200 + b"</svg>")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
         with (
             patch("validate_mermaid.PUPPETEER_CONFIG") as mock_cfg,
-            patch("validate_mermaid.subprocess.run", return_value=success_result) as mock_run,
+            patch(
+                "validate_mermaid.subprocess.run",
+                side_effect=_write_svg_and_succeed,
+            ) as mock_run,
         ):
             mock_cfg.exists.return_value = True
             mock_cfg.__str__ = lambda s: "/tmp/puppeteer-config.json"
@@ -185,10 +194,16 @@ class TestValidateBlockPuppeteerConfig:
     def test_validate_block_returns_true_on_success(self):
         import subprocess
 
-        success_result = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        def _write_svg_and_succeed(cmd, **kwargs):
+            input_flag = cmd.index("--input")
+            from pathlib import Path as _Path
+            out_file = _Path(cmd[input_flag + 1]).with_suffix(".svg")
+            out_file.write_bytes(b"<svg>" + b"x" * 200 + b"</svg>")
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
         with (
             patch("validate_mermaid.PUPPETEER_CONFIG") as mock_cfg,
-            patch("validate_mermaid.subprocess.run", return_value=success_result),
+            patch("validate_mermaid.subprocess.run", side_effect=_write_svg_and_succeed),
         ):
             mock_cfg.exists.return_value = False
             ok, stderr = validate_mermaid.validate_block(1, "graph TD\n  A --> B\n")
@@ -328,7 +343,6 @@ class TestValidateBlockDegenerateSvg:
 
         def _write_empty_svg_and_succeed(cmd, **kwargs):
             # Derive out_path the same way validate_block does
-            import re as _re
             input_flag = cmd.index("--input")
             tmp_file = cmd[input_flag + 1]
             out_file = str(tmp_file).replace(".mmd", ".svg")


### PR DESCRIPTION
```
## Summary

`validate_block()` in `scripts/validate_mermaid.py` previously considered a
diagram valid as long as `mmdc` exited with code 0. Certain versions of
`mermaid-cli` silently produce an empty or near-empty SVG (a Puppeteer layout
failure) while still returning exit code 0. This caused CI to report a
false-green for broken diagrams.

This fix adds a post-run content check: if the output SVG is missing or
smaller than 100 bytes after a zero exit, `validate_block()` now returns
`(False, ...)` with a descriptive message instead of silently passing.

## Changes

**`scripts/validate_mermaid.py` — `validate_block()`**
- Replaced the single-line `return result.returncode == 0, result.stderr` with
  an explicit branch that inspects the output file after a zero exit code.
- If `out_path` does not exist or its size is below the 100-byte threshold,
  the function returns `(False, "mmdc produced an empty/degenerate SVG
  (possible silent render failure)")`.
- Non-zero exit codes continue to return `(False, result.stderr)` as before.

**`tests/test_validate_mermaid.py`**
- Added `TestValidateBlockDegenerateSvg` — a dedicated test class covering the
  degenerate-SVG path. The test patches `subprocess.run` to exit 0 while
  writing a zero-byte SVG, then asserts `validate_block` returns `(False, ...)`.
- Updated `test_validate_block_returns_true_on_success` and
  `test_validate_block_appends_puppeteer_config_when_present` to use a
  `_write_svg_and_succeed` side-effect helper that writes a valid 200-byte SVG
  before returning exit code 0 — these tests would have broken without the
  update because the new size guard would have rejected a missing file.

## Testing

Unit tests:
```
pytest tests/test_validate_mermaid.py -v
```
All existing tests continue to pass. The new `TestValidateBlockDegenerateSvg`
class covers the degenerate-SVG path introduced by this fix.

Manual verification:
1. Create a `.mmd` file with a diagram that triggers a silent Puppeteer failure.
2. Run `python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md`.
3. Confirm the validator reports a failure instead of passing silently.

Closes #139
```