### PR TITLE
fix: resolve #153 - FEATURE: Indicate related concepts

### DIFF
--- a/docs/AZ-104_CheatSheet.md
+++ b/docs/AZ-104_CheatSheet.md
@@ -253,7 +253,7 @@ flowchart TD
 
 | Service | Type | Best For | Key Feature |
 | --- | --- | --- | --- |
-| **Log Analytics Workspace** | Destination | Query, alerting, dashboards | Kusto (KQL) queries; retention config |
+| **Log Analytics Workspace** | Destination | Query, alerting, dashboards | Kusto (KQL) queries; retention config (fed via Diagnostic Settings; contains Activity Log data, KQL engine) |
 | **Azure Storage Account** | Destination | Long-term archive, compliance | Low cost; no real-time query |
 | **Event Hub** | Destination | SIEM integration, streaming | Real-time export to Splunk, Sentinel |
 | **Partner Solutions** | Destination | Third-party observability | Datadog, Elastic natively integrated |
@@ -271,6 +271,11 @@ graph LR
     E --> F[Sentinel / SIEM]
     C --> G[Alerts / Dashboards]
 ```
+
+> **Exam tip:** Activity Log is a sub-component of Azure Monitor, not a standalone service.
+> Route it to Log Analytics Workspace via Diagnostic Settings to enable KQL querying and
+> long-term retention. For AZ-104, use Azure Policy (DeployIfNotExists) to enforce
+> Diagnostic Settings at scale.
 
 ---
 

--- a/docs/AZ-104_CheatSheet.md
+++ b/docs/AZ-104_CheatSheet.md
@@ -253,7 +253,7 @@ flowchart TD
 
 | Service | Type | Best For | Key Feature |
 | --- | --- | --- | --- |
-| **Log Analytics Workspace** | Destination | Query, alerting, dashboards | Kusto (KQL) queries; retention config (fed via Diagnostic Settings; contains Activity Log data, KQL engine) |
+| **Log Analytics Workspace** (fed via Diagnostic Settings; contains Activity Log data, KQL engine) | Destination | Query, alerting, dashboards | Kusto (KQL) queries; retention config |
 | **Azure Storage Account** | Destination | Long-term archive, compliance | Low cost; no real-time query |
 | **Event Hub** | Destination | SIEM integration, streaming | Real-time export to Splunk, Sentinel |
 | **Partner Solutions** | Destination | Third-party observability | Datadog, Elastic natively integrated |

--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -487,9 +487,9 @@ graph TD
 
 | Service | Purpose | Key Concepts |
 | --- | --- | --- |
-| **Azure Monitor** | Central telemetry platform | Metrics, Logs, Alerts, Workbooks (umbrella: Activity Log, Metrics, Alerts, Diagnostic Settings, Insights family) |
-| **Log Analytics Workspace** | Store and query logs (KQL) | Retention (30–730 days), data export (contains: KQL engine, retention tiers; fed via Diagnostic Settings) |
-| **Application Insights** | APM for apps | Live metrics, dependency tracking, availability tests (contains: Live Metrics, Availability Tests, Dependency Tracking, Smart Detection) |
+| **Azure Monitor** (umbrella: Activity Log, Metrics, Alerts, Diagnostic Settings, Insights family) | Central telemetry platform | Metrics, Logs, Alerts, Workbooks |
+| **Log Analytics Workspace** (contains: KQL engine, retention tiers; fed via Diagnostic Settings) | Store and query logs (KQL) | Retention (30–730 days), data export |
+| **Application Insights** (contains: Live Metrics, Availability Tests, Dependency Tracking, Smart Detection) | APM for apps | Live metrics, dependency tracking, availability tests |
 | **VM Insights** | Perf + map for VMs | Relies on Log Analytics agent/AMA |
 | **Container Insights** | AKS monitoring | Pod/node metrics, log collection |
 | **Network Watcher** | Network diagnostics | Packet capture, flow logs, connection monitor |

--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -471,8 +471,9 @@ graph TD
 ```mermaid
 graph TD
     Sources["Data Sources\n(VMs, Apps, PaaS, Logs)"] --> Monitor[Azure Monitor]
+    ActivityLog["Activity Log\n(control-plane events)"] --> Monitor
     Monitor --> Metrics[Metrics]
-    Monitor --> Logs[Log Analytics Workspace]
+    Monitor -->|"via Diagnostic Settings"| Logs[Log Analytics Workspace]
     Monitor --> Alerts[Alerts & Action Groups]
     Monitor --> Insights[Insights: VM, Container, App]
     Logs --> Sentinel[Microsoft Sentinel]
@@ -486,9 +487,9 @@ graph TD
 
 | Service | Purpose | Key Concepts |
 | --- | --- | --- |
-| **Azure Monitor** | Central telemetry platform | Metrics, Logs, Alerts, Workbooks |
-| **Log Analytics Workspace** | Store and query logs (KQL) | Retention (30–730 days), data export |
-| **Application Insights** | APM for apps | Live metrics, dependency tracking, availability tests |
+| **Azure Monitor** | Central telemetry platform | Metrics, Logs, Alerts, Workbooks (umbrella: Activity Log, Metrics, Alerts, Diagnostic Settings, Insights family) |
+| **Log Analytics Workspace** | Store and query logs (KQL) | Retention (30–730 days), data export (contains: KQL engine, retention tiers; fed via Diagnostic Settings) |
+| **Application Insights** | APM for apps | Live metrics, dependency tracking, availability tests (contains: Live Metrics, Availability Tests, Dependency Tracking, Smart Detection) |
 | **VM Insights** | Perf + map for VMs | Relies on Log Analytics agent/AMA |
 | **Container Insights** | AKS monitoring | Pod/node metrics, log collection |
 | **Network Watcher** | Network diagnostics | Packet capture, flow logs, connection monitor |
@@ -504,10 +505,15 @@ graph TD
 | --- | --- | --- |
 | **Metric Alert** | Threshold on metric value | CPU > 80%, response time > 2s |
 | **Log Alert** | KQL query result count/value | Error count in last 5 min > 10 |
-| **Activity Log Alert** | Azure control-plane events | Who deleted a resource, policy assignment |
+| **Activity Log Alert** | Azure control-plane events | Who deleted a resource, policy assignment (Activity Log is a sub-component of Azure Monitor, routed to Log Analytics via Diagnostic Settings) |
 | **Smart Detection** | AI-based anomaly in App Insights | Failure rate spikes, perf degradation |
 
 > **Action Groups** decouple alert routing from alert rules. One action group → multiple rules.
+
+> **Exam tip:** When an answer option names a specific sub-component (e.g. Activity Log,
+> Live Metrics, Smart Detection), prefer it over the umbrella service (e.g. Azure Monitor,
+> Application Insights). Select the umbrella only when the sub-component is absent from
+> the options.
 
 ---
 
@@ -515,7 +521,8 @@ graph TD
 
 - Send to: **Log Analytics Workspace**, **Storage Account**, **Event Hub**, **Partner solution**
 - Configure per resource (or via Azure Policy at scale)
-- Categories: AllMetrics, Audit, Operational, etc.
+- Categories: AllMetrics, Audit, Operational, **Activity Log** (control-plane events), etc.
+- Activity Log is a sub-component of Azure Monitor routed to Log Analytics Workspace via Diagnostic Settings — not a standalone service.
 
 ---
 

--- a/tests/test_issue_153_related_concepts.py
+++ b/tests/test_issue_153_related_concepts.py
@@ -1,0 +1,118 @@
+"""Tests for issue #153 - FEATURE: Indicate related concepts in AZ-305 and AZ-104 cheatsheets."""
+
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+AZ305 = REPO_ROOT / "docs" / "AZ-305_CheatSheet.md"
+AZ104 = REPO_ROOT / "docs" / "AZ-104_CheatSheet.md"
+
+
+@pytest.fixture(scope="module")
+def az305_text():
+    return AZ305.read_text()
+
+
+@pytest.fixture(scope="module")
+def az104_text():
+    return AZ104.read_text()
+
+
+class TestAZ305AzureMonitorAnnotation:
+    """Task 1: Azure Monitor Service cell annotated with umbrella components."""
+
+    def test_azure_monitor_umbrella_annotation(self, az305_text):
+        assert "umbrella: Activity Log, Metrics, Alerts, Diagnostic Settings, Insights family" in az305_text
+
+
+class TestAZ305LogAnalyticsAnnotation:
+    """Task 2: Log Analytics Workspace Service cell annotated."""
+
+    def test_log_analytics_annotation(self, az305_text):
+        assert "contains: KQL engine, retention tiers; fed via Diagnostic Settings" in az305_text
+
+
+class TestAZ305AppInsightsAnnotation:
+    """Task 3: Application Insights Service cell annotated."""
+
+    def test_app_insights_annotation(self, az305_text):
+        assert "contains: Live Metrics, Availability Tests, Dependency Tracking, Smart Detection" in az305_text
+
+
+class TestAZ305ActivityLogAlertExpanded:
+    """Task 4: Activity Log Alert Use Case cell expanded."""
+
+    def test_activity_log_alert_use_case_expanded(self, az305_text):
+        assert "Activity Log is a sub-component of Azure Monitor, routed to Log Analytics via Diagnostic Settings" in az305_text
+
+
+class TestAZ305ExamTipAfterActionGroups:
+    """Task 5: Exam tip inserted after Action Groups note."""
+
+    def test_exam_tip_sub_component_preference(self, az305_text):
+        assert "prefer it over the umbrella service" in az305_text
+
+    def test_exam_tip_mentions_activity_log_and_live_metrics(self, az305_text):
+        assert "Activity Log" in az305_text
+        assert "Live Metrics" in az305_text
+        assert "Smart Detection" in az305_text
+
+    def test_exam_tip_appears_before_diagnostic_settings_section(self, az305_text):
+        tip_pos = az305_text.find("prefer it over the umbrella service")
+        diag_pos = az305_text.find("## Diagnostic Settings")
+        assert tip_pos != -1
+        assert diag_pos != -1
+        assert tip_pos < diag_pos
+
+
+class TestAZ305DiagnosticSettingsCategories:
+    """Task 6: Categories bullet updated with Activity Log."""
+
+    def test_activity_log_category_listed(self, az305_text):
+        assert "**Activity Log** (control-plane events)" in az305_text
+
+    def test_activity_log_not_standalone_bullet(self, az305_text):
+        assert "Activity Log is a sub-component of Azure Monitor routed to Log Analytics Workspace via Diagnostic Settings" in az305_text
+
+
+class TestAZ305MermaidDiagram:
+    """Task 7: Mermaid diagram updated with ActivityLog node and Diagnostic Settings edge."""
+
+    def test_activity_log_node_exists(self, az305_text):
+        assert 'ActivityLog["Activity Log' in az305_text
+
+    def test_activity_log_feeds_monitor(self, az305_text):
+        assert "ActivityLog" in az305_text
+        assert "--> Monitor" in az305_text
+
+    def test_diagnostic_settings_edge_label(self, az305_text):
+        assert 'via Diagnostic Settings' in az305_text
+
+    def test_no_bare_monitor_to_logs_edge(self, az305_text):
+        # The old plain edge "Monitor --> Logs[Log Analytics" should be replaced
+        assert "Monitor --> Logs[Log Analytics" not in az305_text
+
+
+class TestAZ104LogAnalyticsAnnotation:
+    """Task 9: Log Analytics Workspace in AZ-104 Diagnostic Settings table annotated."""
+
+    def test_log_analytics_annotation_az104(self, az104_text):
+        assert "fed via Diagnostic Settings; contains Activity Log data, KQL engine" in az104_text
+
+
+class TestAZ104ExamTip:
+    """Task 10: Exam tip inserted after Diagnostic Settings Routing diagram in AZ-104."""
+
+    def test_exam_tip_activity_log_sub_component(self, az104_text):
+        assert "Activity Log is a sub-component of Azure Monitor, not a standalone service" in az104_text
+
+    def test_exam_tip_mentions_deployifnotexists(self, az104_text):
+        assert "DeployIfNotExists" in az104_text
+
+    def test_exam_tip_appears_after_routing_diagram(self, az104_text):
+        diagram_pos = az104_text.find("Diagnostic Settings Routing")
+        tip_pos = az104_text.find("Activity Log is a sub-component of Azure Monitor, not a standalone service")
+        assert diagram_pos != -1
+        assert tip_pos != -1
+        assert tip_pos > diagram_pos

--- a/tests/test_issue_153_related_concepts.py
+++ b/tests/test_issue_153_related_concepts.py
@@ -23,7 +23,8 @@ class TestAZ305AzureMonitorAnnotation:
     """Task 1: Azure Monitor Service cell annotated with umbrella components."""
 
     def test_azure_monitor_umbrella_annotation(self, az305_text):
-        assert "umbrella: Activity Log, Metrics, Alerts, Diagnostic Settings, Insights family" in az305_text
+        needle = "umbrella: Activity Log, Metrics, Alerts, Diagnostic Settings, Insights family"
+        assert needle in az305_text
 
 
 class TestAZ305LogAnalyticsAnnotation:
@@ -37,14 +38,19 @@ class TestAZ305AppInsightsAnnotation:
     """Task 3: Application Insights Service cell annotated."""
 
     def test_app_insights_annotation(self, az305_text):
-        assert "contains: Live Metrics, Availability Tests, Dependency Tracking, Smart Detection" in az305_text
+        needle = "contains: Live Metrics, Availability Tests, Dependency Tracking, Smart Detection"
+        assert needle in az305_text
 
 
 class TestAZ305ActivityLogAlertExpanded:
     """Task 4: Activity Log Alert Use Case cell expanded."""
 
     def test_activity_log_alert_use_case_expanded(self, az305_text):
-        assert "Activity Log is a sub-component of Azure Monitor, routed to Log Analytics via Diagnostic Settings" in az305_text
+        needle = (
+            "Activity Log is a sub-component of Azure Monitor, "
+            "routed to Log Analytics via Diagnostic Settings"
+        )
+        assert needle in az305_text
 
 
 class TestAZ305ExamTipAfterActionGroups:
@@ -73,7 +79,11 @@ class TestAZ305DiagnosticSettingsCategories:
         assert "**Activity Log** (control-plane events)" in az305_text
 
     def test_activity_log_not_standalone_bullet(self, az305_text):
-        assert "Activity Log is a sub-component of Azure Monitor routed to Log Analytics Workspace via Diagnostic Settings" in az305_text
+        needle = (
+            "Activity Log is a sub-component of Azure Monitor routed to "
+            "Log Analytics Workspace via Diagnostic Settings"
+        )
+        assert needle in az305_text
 
 
 class TestAZ305MermaidDiagram:
@@ -105,14 +115,16 @@ class TestAZ104ExamTip:
     """Task 10: Exam tip inserted after Diagnostic Settings Routing diagram in AZ-104."""
 
     def test_exam_tip_activity_log_sub_component(self, az104_text):
-        assert "Activity Log is a sub-component of Azure Monitor, not a standalone service" in az104_text
+        needle = "Activity Log is a sub-component of Azure Monitor, not a standalone service"
+        assert needle in az104_text
 
     def test_exam_tip_mentions_deployifnotexists(self, az104_text):
         assert "DeployIfNotExists" in az104_text
 
     def test_exam_tip_appears_after_routing_diagram(self, az104_text):
         diagram_pos = az104_text.find("Diagnostic Settings Routing")
-        tip_pos = az104_text.find("Activity Log is a sub-component of Azure Monitor, not a standalone service")
+        needle = "Activity Log is a sub-component of Azure Monitor, not a standalone service"
+        tip_pos = az104_text.find(needle)
         assert diagram_pos != -1
         assert tip_pos != -1
         assert tip_pos > diagram_pos


### PR DESCRIPTION
## Summary

The AZ-305 and AZ-104 cheat sheets presented Azure Monitor, Log Analytics Workspace, and Application Insights as flat, unrelated entries — giving no indication that some services are umbrella platforms containing distinct, separately-nameable sub-components. During exam scenarios this causes a common error: selecting the umbrella service (e.g. Azure Monitor) when the question expects the most specific named component (e.g. Activity Log Alert), or vice versa.

This PR annotates the containment relationships directly in the service tables and Mermaid diagram so the hierarchy is unambiguous at a glance.

## Changes

**docs/AZ-305_CheatSheet.md**

- `graph TD` Mermaid diagram (Azure Monitor Ecosystem): added `ActivityLog` as an explicit input node feeding into `Azure Monitor`, and labelled the `Monitor → Logs` edge with `via Diagnostic Settings`. Both relationships were implied before; they are now visually explicit.
- Key Services table: expanded the `Azure Monitor`, `Log Analytics Workspace`, and `Application Insights` entries with parenthetical sub-component lists so the umbrella/contained relationship is stated inline rather than inferred.
- Alerts table: annotated the `Activity Log Alert` row to clarify that Activity Log is a sub-component of Azure Monitor routed to Log Analytics Workspace via Diagnostic Settings — not a standalone service.

**docs/AZ-104_CheatSheet.md**

- Diagnostic Settings destinations table: expanded the `Log Analytics Workspace` entry with a note that it is fed via Diagnostic Settings and contains Activity Log data and the KQL engine.
- Added an exam-tip callout after the Diagnostic Settings diagram reinforcing the Activity Log → Diagnostic Settings → Log Analytics Workspace routing pattern, and noting that Azure Policy (DeployIfNotExists) can enforce this at scale for the AZ-104 scenario.

**tests/test_issue_153_related_concepts.py**

- 130-line test suite validating the presence of the umbrella annotations, the Activity Log node in the Mermaid diagram, the `via Diagnostic Settings` edge label, and the exam-tip callout text in both cheat sheet files.

## Testing

Automated:

```bash
python3 -m pytest tests/test_issue_153_related_concepts.py -v
```

Markdown lint (no new violations expected):

```bash
npx markdownlint-cli2 "**/*.md"
```

Mermaid validation:

```bash
python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md
```

Manual review: open `docs/AZ-305_CheatSheet.md` around lines 471–520 and confirm the Mermaid diagram renders the `ActivityLog` node and `via Diagnostic Settings` edge correctly on GitHub.

Closes #153