### PR TITLE
fix: resolve #170 - FEATURE: Indicate Deprecation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ clean, reviewable contributions to this repository.
 7. [Commit Message Style](#7-commit-message-style)
 8. [Pull Request Process](#8-pull-request-process)
 9. [Coding Standards](#9-coding-standards)
+10. [Deprecation warnings](#10-deprecation-warnings)
 
 ---
 
@@ -65,6 +66,7 @@ and leave a comment so someone else can pick it up.
 | `docs/`    | `docs/<topic>`                  | Meta-documentation (README, CONTRIBUTING)  |
 
 Examples:
+
 - `feature/42-networking-private-endpoints`
 - `fix/17-storage-redundancy-table`
 - `docs/update-contributing-guide`
@@ -193,3 +195,20 @@ Closes #42
 - Follow PEP 8. Use `ruff` for linting and formatting.
 - Keep scripts small and single-purpose.
 - Add or update tests in `tests/` whenever script behaviour changes.
+
+---
+
+## 10. Deprecation warnings
+
+Use a deprecation callout immediately after the affected table row or section heading when a service
+is retired, retiring, or superseded. Format:
+
+> **⚠️ Deprecation warning:** \<Service\> is retired / retiring \<date if known\>. Migrate to
+> \<replacement\>. See: [announcement link]
+
+Rules:
+
+- Place the callout directly after the table that contains the deprecated service.
+- Always name the recommended replacement.
+- Include the retirement date when officially announced.
+- Do NOT use the exam-tip format for deprecation notices — they serve different purposes.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ When editing or adding material:
   Do not use plain blockquotes, bold sentences, or note/warning admonitions
   for exam tips.
 
+- For retired, retiring, or superseded services, use a deprecation callout
+  instead of an exam-tip. See the [Deprecation warnings](CONTRIBUTING.md#10-deprecation-warnings)
+  section in CONTRIBUTING.md for the required format.
+
 - Use Mermaid diagrams for branching decision flows where a visual aid is more
   useful than prose alone. Choose the variant by purpose:
 

--- a/docs/AZ-104_CheatSheet.md
+++ b/docs/AZ-104_CheatSheet.md
@@ -112,6 +112,10 @@ flowchart TD
 | **Key Vault - Azure RBAC** | Role-based model | Consistent RBAC governance | Entra ID roles; supports PIM; audit trail |
 | **Managed Identity** | Identity type | App-to-Key Vault auth | No credentials; auto-rotated by Azure |
 
+> **⚠️ Deprecation warning:** Vault Access Policies are the legacy authorization model for
+> Key Vault. Microsoft recommends migrating to **Azure RBAC** for new and existing vaults.
+> RBAC provides Entra-native granularity, PIM support, and a unified audit trail.
+
 > **Exam tip:** Microsoft recommends Key Vault Azure RBAC over Access Policies for new deployments. RBAC supports Privileged Identity Management (PIM) for just-in-time access.
 
 ### Key Vault Access Decision Flow
@@ -230,6 +234,10 @@ flowchart TD
 | **MMA / OMS Agent (legacy)** | OS-level | VM | Being retired (Aug 2024) | Single workspace; no DCR support |
 | **Diagnostics Extension (WAD/LAD)** | OS-level | VM | Guest OS metrics/logs to Azure Storage | XML config; not Log Analytics native |
 | **Dependency Agent** | Network | VM | Service Map, VM Insights connectivity | Requires AMA or MMA; maps processes |
+
+> **⚠️ Deprecation warning:** The MMA/OMS (Microsoft Monitoring Agent / OMS Agent) is retired
+> (August 2024). Migrate all VM monitoring deployments to **Azure Monitor Agent (AMA)** with
+> Data Collection Rules (DCR).
 
 > **Exam tip:** The MMA/OMS agent is retired. For AZ-104, always choose AMA with Data Collection Rules for new deployments. DCRs allow filtering and routing to multiple destinations.
 
@@ -430,6 +438,10 @@ graph TD
     B --> F[Azure Files]
     C --> G[Replicated VMs - failover ready]
 ```
+
+> **⚠️ Deprecation warning:** Recovery Services Vault is the legacy backup store (VMs, SQL
+> in VM, Azure Files). For new PaaS-based backup targets (Blobs, managed databases), use
+> **Backup Vault** — Microsoft's current backup store model.
 
 ---
 

--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -154,6 +154,11 @@ flowchart TD
 | **Private Endpoint** | L3 | Regional | Private IP access to PaaS services inside a VNet | NIC injected into VNet; DNS integration required |
 | **Service Endpoint** | L3 | Regional | Route PaaS traffic over Azure backbone from a subnet | No private IP; PaaS firewall can restrict to specific subnets |
 
+> **⚠️ Deprecation warning:** VNet-to-VNet VPN is superseded by VNet Peering for most
+> cross-region and cross-subscription connectivity scenarios. Prefer peering (lower latency,
+> no gateway required). Retain VNet-to-VNet VPN only when IPSec encryption across the Azure
+> backbone is an explicit requirement.
+
 > **Private Endpoint vs Service Endpoint:**
 >
 > - Private Endpoint = PaaS resource gets a NIC in your VNet (true private)
@@ -247,9 +252,13 @@ flowchart TD
 | **Azure Front Door** | L7 (HTTP/S) | Global | CDN + WAF + global LB combined | Anycast PoP, WAF, SSL offload, caching rules |
 | **Azure CDN (Microsoft)** | L7 (HTTP/S) | Global | Static asset delivery, simple CDN | Verizon/Akamai PoPs, rules engine, legacy option |
 
-> **Exam tip:** Azure CDN classic profiles (Verizon, Akamai) are being retired. For new
-> architectures requiring CDN, Microsoft recommends Azure Front Door. Choose Front Door when
-> the requirement mentions CDN *plus* WAF, global load balancing, or SSL offload at the edge.
+> **⚠️ Deprecation warning:** Azure CDN classic profiles (Verizon and Akamai) are retiring
+> 30 September 2027. Migrate to **Azure Front Door** (CDN + WAF + global LB) or
+> **Azure CDN Standard from Microsoft** for pure CDN workloads.
+> See: [Microsoft retirement announcement](https://learn.microsoft.com/en-us/azure/cdn/classic-cdn-retirement-faq)
+
+> **Exam tip:** Choose Azure Front Door when the requirement mentions global HTTP load balancing,
+> WAF, or SSL offload at the edge.
 
 ---
 
@@ -291,11 +300,13 @@ graph LR
 
 ---
 
-> **Exam tip (AZ-500):** Microsoft Defender for Cloud is the current name —
-> "Security Center" and "Azure Defender" are legacy names that may appear
-> in older questions. JIT VM Access (under Defender for Servers) locks down
-> management ports and opens them only on approved request; choose it when
-> the requirement mentions reducing the attack surface on VM management ports.
+> **⚠️ Deprecation warning:** "Security Center" and "Azure Defender" are legacy names.
+> The current product is **Microsoft Defender for Cloud**. Older exam questions may still
+> use the former names.
+
+> **Exam tip (AZ-500):** JIT VM Access (under Defender for Servers) locks down management
+> ports and opens them only on approved request; choose it when the requirement mentions
+> reducing the attack surface on VM management ports.
 
 ## Azure Key Vault
 
@@ -317,6 +328,10 @@ graph LR
 | --- | --- | --- | --- | --- |
 | **Key Vault** | Vault Access Policies (legacy) | Per-vault log; no per-operation identity trail | Coarse — get/list/set apply to all secrets | Simple setup; max 1024 policies per vault |
 | **Key Vault** | Azure RBAC | Full Azure Activity Log + Entra audit trail | Fine-grained — role assignment per secret/key/cert | Entra-native; supports PIM, Conditional Access |
+
+> **⚠️ Deprecation warning:** Vault Access Policies are the legacy authorization model for
+> Key Vault. Microsoft recommends migrating to **Azure RBAC** for new and existing vaults.
+> RBAC provides Entra-native granularity, PIM support, and a unified audit trail.
 
 > **Exam tip:** Choose Azure RBAC for Key Vault when the requirement mentions
 > Entra integration, Privileged Identity Management (PIM), per-resource
@@ -820,7 +835,9 @@ flowchart TD
 | **Custom Roles** | Define your own action list |
 | **Deny Assignments** | Block actions regardless of role (used by Blueprints) |
 
-> Prefer RBAC over legacy Access Policies (Key Vault, Storage). RBAC is auditable and centralized.
+> **⚠️ Deprecation warning:** Vault Access Policies (Key Vault) and legacy Storage access
+> policies are superseded by **Azure RBAC**. RBAC is Entra-native, auditable, and centrally
+> managed. Migrate new and existing resources to RBAC.
 
 ---
 
@@ -889,7 +906,9 @@ graph TD
 | Azure Blobs | Backup Vault | Operational backup (no vault egress) |
 | PostgreSQL / MySQL | Backup Vault | Managed DB backup |
 
-> **Recovery Services Vault** = legacy + VMs + SQL.  **Backup Vault** = newer PaaS services.
+> **⚠️ Deprecation warning:** Recovery Services Vault is the legacy backup store (VMs, SQL
+> in VM, Azure Files). For new PaaS-based backup targets (Blobs, managed databases), use
+> **Backup Vault** — Microsoft's current backup store model.
 
 ---
 
@@ -928,7 +947,7 @@ graph TD
 | **Terraform** | Multi-cloud IaC | Yes (plan) | Stateful | Active |
 | **Azure Blueprints** | Governance packages (policy + RBAC + ARM) | Partial (locking) | Artifact-tracked | **RETIRED July 2026** |
 
-> **Azure Blueprints is retired (July 2026).** Migrate to:
+> **⚠️ Deprecation warning:** Azure Blueprints is retired (11 July 2026). Migrate to:
 >
 > - **ARM/Bicep Template Specs** — for reusable, versioned IaC artifacts.
 > - **Azure Policy** — for compliance rules and auto-remediation.


### PR DESCRIPTION
## Summary

Issue #170 identified that deprecated and retiring Azure services across the cheat sheets were either unmarked or inconsistently marked, creating a risk that exam candidates study from stale information and recommend retiring services in architect-level answers. Azure Blueprints retires July 2026, making this time-sensitive.

This PR establishes a single, distinct deprecation callout format, documents it in CONTRIBUTING.md and README.md, and applies it to all affected locations in both cheat sheets.

## Changes

**CONTRIBUTING.md — new section 10: Deprecation warnings**
Defines the canonical `> **⚠️ Deprecation warning:**` blockquote format, distinct from the existing exam-tip format. Rules cover placement (directly after the affected table), required replacement naming, retirement date inclusion, and the explicit prohibition on using exam-tip format for deprecations. A new TOC entry and branch-name example line were also tidied up.

**README.md — deprecation callout mention**
Added a brief pointer to the new CONTRIBUTING.md section so contributors editing the cheat sheets see the requirement without having to hunt for it.

**docs/AZ-305_CheatSheet.md — seven callout locations updated**
- Azure CDN classic profiles (Verizon/Akamai): new deprecation callout after the CDN table with retirement timeline and recommended replacement (Azure Front Door / Azure CDN Standard from Microsoft).
- VNet-to-VNet VPN: new callout noting the pattern is superseded by VNet peering for most scenarios, with guidance on when a VPN tunnel remains appropriate.
- Security Center / Azure Defender: legacy-name note converted from exam-tip format to deprecation callout format.
- Key Vault Vault Access Policies (line 318): existing exam-tip supplemented with a dedicated deprecation callout recommending migration to Azure RBAC.
- RBAC over legacy Access Policies (line 823): plain blockquote replaced with a properly formatted deprecation callout.
- Recovery Services Vault (line 892): plain blockquote aligned to the new deprecation callout pattern.
- Azure Blueprints (lines 929–940): existing bold retirement callout reformatted to the new standard pattern, preserving retirement date and migration path.

**docs/AZ-104_CheatSheet.md — two callout locations added**
- Key Vault Vault Access Policies: deprecation callout added before the existing exam-tip, recommending Azure RBAC with Entra-native granularity and PIM support.
- MMA/OMS Agent: deprecation callout added noting the August 2024 retirement and directing readers to Azure Monitor Agent (AMA) with Data Collection Rules.

## Testing

1. Markdown lint — run from repo root:
   ```
   npx markdownlint-cli2 "**/*.md"
   ```
   No new violations should appear.

2. Mermaid validation — run from repo root:
   ```
   python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md
   ```
   All diagrams should pass with no errors.

3. Manual review — confirm each new callout:
   - Uses the `> **⚠️ Deprecation warning:**` prefix exactly.
   - Names a recommended replacement.
   - Includes a retirement date where officially announced.
   - Is placed directly after the relevant table, not inside a table cell.
   - Does not use the exam-tip blockquote format.

Closes #170