### PR TITLE
fix: resolve #161 - BUG: Add unit tests for extract_mermaid_blocks() file-read e

### DIFF
--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -165,6 +165,24 @@ class TestExtractMermaidBlocksFromFile:
         assert "graph TD" in result[0]
 
 
+class TestExtractMermaidBlocksFileErrors:
+    """Tests for extract_mermaid_blocks() file-read error paths."""
+
+    def test_raises_on_permission_error(self, tmp_path):
+        md = tmp_path / "locked.md"
+        md.write_text("```mermaid\ngraph TD\n  A-->B\n```", encoding="utf-8")
+        md.chmod(0o000)
+        with pytest.raises((RuntimeError, PermissionError)):
+            validate_mermaid.extract_mermaid_blocks(str(md))
+        md.chmod(0o644)  # restore so pytest can clean up tmp_path
+
+    def test_raises_on_encoding_error(self, tmp_path):
+        md = tmp_path / "binary.md"
+        md.write_bytes(b"\xff\xfe invalid utf-8")
+        with pytest.raises((RuntimeError, UnicodeDecodeError)):
+            validate_mermaid.extract_mermaid_blocks(str(md))
+
+
 class TestValidateBlockPuppeteerConfig:
     """Tests for puppeteer config branch in validate_block()."""
 


### PR DESCRIPTION
## Summary

Issue #161 identified two untested error paths in `extract_mermaid_blocks()`: a `PermissionError` when the file cannot be opened, and a `UnicodeDecodeError` when the file contains non-UTF-8 bytes. Both are reachable in CI on Linux runners. Without tests covering these branches, any regression in error handling would pass undetected.

## Changes

**`tests/test_validate_mermaid.py`**

Added a new `TestExtractMermaidBlocksFileErrors` class with two test cases:

- `test_raises_on_permission_error` — creates a `locked.md` file, sets permissions to `0o000`, and asserts that `extract_mermaid_blocks()` raises either `RuntimeError` or `PermissionError`. Permissions are restored after the assertion so pytest can clean up `tmp_path`.
- `test_raises_on_encoding_error` — writes raw bytes (`\xff\xfe`) that are invalid UTF-8 and asserts that `extract_mermaid_blocks()` raises either `RuntimeError` or `UnicodeDecodeError`.

Both tests accept the union of the raw OS exception and a wrapped `RuntimeError` to remain valid regardless of whether the companion fix (wrapping) has been applied.

## Testing

Run the full test suite with coverage:

```bash
pytest tests/ --cov=scripts --cov-fail-under=90
```

Run linting:

```bash
ruff check scripts/ tests/
```

Both commands must pass with no errors. The two new tests will be green if the companion fix issue has already been merged, or will document expected behaviour if it has not.

Closes #161