### PR TITLE
fix: resolve #160 - BUG: Handle PermissionError and UnicodeDecodeError in extrac

### DIFF
--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -43,8 +43,11 @@ def _extract_from_text(text: str) -> list[str]:
 
 
 def extract_mermaid_blocks(md_path):
-    with open(md_path, encoding="utf-8") as f:
-        content = f.read()
+    try:
+        with open(md_path, encoding="utf-8") as f:
+            content = f.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise RuntimeError(f"Cannot read {md_path}: {exc}") from exc
     return _extract_from_text(content)
 
 
@@ -102,7 +105,11 @@ def run(md_paths: list[str]) -> int:
         if not str(resolved).startswith(str(repo_root) + "/") and resolved != repo_root:
             print(f"Error: path outside repository root: {md_path}", file=sys.stderr)
             return 1
-        blocks = extract_mermaid_blocks(md_path)
+        try:
+            blocks = extract_mermaid_blocks(md_path)
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
         print(f"Found {len(blocks)} mermaid diagram(s) in {md_path}")
         if not blocks:
             print("WARNING: no mermaid blocks found — check fence syntax.", file=sys.stderr)

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -185,15 +185,49 @@ class TestExtractMermaidBlocksFileErrors:
         md = tmp_path / "locked.md"
         md.write_text("```mermaid\ngraph TD\n  A-->B\n```", encoding="utf-8")
         md.chmod(0o000)
-        with pytest.raises((RuntimeError, PermissionError)):
+        with pytest.raises(RuntimeError) as excinfo:
             validate_mermaid.extract_mermaid_blocks(str(md))
         md.chmod(0o644)  # restore so pytest can clean up tmp_path
+        assert str(md) in str(excinfo.value)
 
     def test_raises_on_encoding_error(self, tmp_path):
         md = tmp_path / "binary.md"
         md.write_bytes(b"\xff\xfe invalid utf-8")
-        with pytest.raises((RuntimeError, UnicodeDecodeError)):
+        with pytest.raises(RuntimeError) as excinfo:
             validate_mermaid.extract_mermaid_blocks(str(md))
+        assert str(md) in str(excinfo.value)
+
+
+class TestRunFileReadErrors:
+    """Tests for run() handling RuntimeError raised by extract_mermaid_blocks."""
+
+    def test_run_returns_1_on_runtime_error(self, tmp_path):
+        md = tmp_path / "test.md"
+        md.write_text("# test", encoding="utf-8")
+        with (
+            patch("validate_mermaid.Path.is_file", return_value=True),
+            patch(
+                "validate_mermaid.extract_mermaid_blocks",
+                side_effect=RuntimeError(f"Cannot read {md}: permission denied"),
+            ),
+        ):
+            result = validate_mermaid.run([str(md)])
+        assert result == 1
+
+    def test_run_prints_error_to_stderr_on_runtime_error(self, tmp_path, capsys):
+        md = tmp_path / "test.md"
+        md.write_text("# test", encoding="utf-8")
+        error_msg = f"Cannot read {md}: permission denied"
+        with (
+            patch("validate_mermaid.Path.is_file", return_value=True),
+            patch(
+                "validate_mermaid.extract_mermaid_blocks",
+                side_effect=RuntimeError(error_msg),
+            ),
+        ):
+            validate_mermaid.run([str(md)])
+        captured = capsys.readouterr()
+        assert error_msg in captured.err
 
 
 class TestValidateBlockPuppeteerConfig:

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -204,11 +204,13 @@ class TestRunFileReadErrors:
     def test_run_returns_1_on_runtime_error(self, tmp_path):
         md = tmp_path / "test.md"
         md.write_text("# test", encoding="utf-8")
+        error_msg = f"Cannot read {md}: permission denied"
         with (
             patch("validate_mermaid.Path.is_file", return_value=True),
+            patch("validate_mermaid._repo_root", return_value=tmp_path),
             patch(
                 "validate_mermaid.extract_mermaid_blocks",
-                side_effect=RuntimeError(f"Cannot read {md}: permission denied"),
+                side_effect=RuntimeError(error_msg),
             ),
         ):
             result = validate_mermaid.run([str(md)])
@@ -220,6 +222,7 @@ class TestRunFileReadErrors:
         error_msg = f"Cannot read {md}: permission denied"
         with (
             patch("validate_mermaid.Path.is_file", return_value=True),
+            patch("validate_mermaid._repo_root", return_value=tmp_path),
             patch(
                 "validate_mermaid.extract_mermaid_blocks",
                 side_effect=RuntimeError(error_msg),


### PR DESCRIPTION
## Summary

Resolves #160 — Wraps the bare `open()` call in `extract_mermaid_blocks()` so that unreadable or non-UTF-8 files produce a clean `RuntimeError` instead of a raw Python traceback, and ensures `run()` catches and reports that error to stderr with exit code 1.

## Changes

- **scripts/validate_mermaid.py**: Wrapped the `open()` call in `extract_mermaid_blocks()` with a `try/except (OSError, UnicodeDecodeError)` block that re-raises as a descriptive `RuntimeError`, preserving the original cause via exception chaining. Added a `try/except RuntimeError` in `run()` that prints the message to stderr and returns exit code 1 instead of propagating the exception.
- **tests/test_validate_mermaid.py**: Tightened the two existing file-error tests in `TestExtractMermaidBlocksFileErrors` to assert that `RuntimeError` (not the raw OS or encoding exception) is raised and that the offending path appears in the message. Added a new `TestRunFileReadErrors` class with two tests — one verifying `run()` returns 1 and one verifying the error message reaches stderr — both using `patch` to inject a `RuntimeError` without touching the filesystem.

## Testing

Run the full test suite and coverage gate:

```
pytest tests/ --cov=scripts --cov-fail-under=90
```

`TestExtractMermaidBlocksFileErrors` and the new `TestRunFileReadErrors` class cover all acceptance criteria paths. Linting: `ruff check scripts/` passes with no new violations.

Closes #160