### PR TITLE
fix: resolve issue #191 - BUG: Extend ruff lint scope to cover tests/…

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Install ruff
         run: pip install "ruff>=0.11.0"
       - name: Lint
-        run: ruff check scripts/
+        run: ruff check scripts/ tests/
       - name: Format check
-        run: ruff format --check scripts/
+        run: ruff format --check scripts/ tests/
 
   python-test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,9 @@ repos:
     rev: v0.11.13
     hooks:
       - id: ruff
-        args: [--fix]
+        args: [--fix, scripts/, tests/]
       - id: ruff-format
+        args: [scripts/, tests/]
 
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.17.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ select = [
 ]
 ignore = []
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["scripts"]
 

--- a/tests/test_issue_153_related_concepts.py
+++ b/tests/test_issue_153_related_concepts.py
@@ -97,7 +97,7 @@ class TestAZ305MermaidDiagram:
         assert "--> Monitor" in az305_text
 
     def test_diagnostic_settings_edge_label(self, az305_text):
-        assert 'via Diagnostic Settings' in az305_text
+        assert "via Diagnostic Settings" in az305_text
 
     def test_no_bare_monitor_to_logs_edge(self, az305_text):
         # The old plain edge "Monitor --> Logs[Log Analytics" should be replaced

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -96,7 +96,7 @@ class TestExtractMermaidBlocks:
             # python_block_with_backtick_string_precedes_mermaid — greedy matching must not
             # capture the Python block as part of the diagram
             (
-                "```python\nx = \"```\"\n```\n\n```mermaid\ngraph TD\n  A-->B\n```",
+                '```python\nx = "```"\n```\n\n```mermaid\ngraph TD\n  A-->B\n```',
                 1,
                 "graph TD\n  A-->B\n",
             ),


### PR DESCRIPTION
This pull request expands linting and formatting checks to include the `tests/` directory, improves pre-commit configuration for Ruff, and updates linting rules for test files. It also contains minor test code cleanups for consistency.

**Linting and formatting improvements:**

* The GitHub Actions workflow now runs Ruff lint and format checks on both `scripts/` and `tests/` directories instead of just `scripts/`.
* The `.pre-commit-config.yaml` file is updated so Ruff and Ruff-format hooks explicitly include both `scripts/` and `tests/` directories.
* Ruff configuration in `pyproject.toml` now ignores the `S101` lint rule (use of `assert`) in all files under `tests/`.

**Test code consistency:**

* Minor string formatting changes in test assertions to use consistent quote styles in `tests/test_issue_153_related_concepts.py` and `tests/test_validate_mermaid.py`. [[1]](diffhunk://#diff-c57f57e3c923667c862d9f9a99e46d086a786f9f447892e429e89a750639289fL100-R100) [[2]](diffhunk://#diff-e4774462c6209a2c37db0fc608fc03cade5d40851b44d99a560eb88e79a63b23L99-R99)