### PR TITLE
fix: resolve #193 - FEATURE: Add a Mermaid decision flowchart for storage tier s

### DIFF
--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -438,6 +438,15 @@ as the credential-free pattern — no secrets stored in application configuratio
 > through tiers. Archive blobs must be rehydrated to Hot or Cool before access;
 > plan for rehydration latency in recovery scenarios.
 
+```mermaid
+flowchart TD
+    A[Access frequency?] -->|Frequent reads/writes| B[Hot tier]
+    A -->|Infrequent, cost-sensitive; 30-day min| C[Cool tier]
+    A -->|Rarely accessed; 90-day min| D[Cold tier]
+    A -->|Archival, rare access; 180-day min| E[Archive tier]
+    E --> F[Note: requires rehydration to Hot or Cool before read]
+```
+
 ---
 
 ## Storage Redundancy


### PR DESCRIPTION
## Summary

Resolves #193 — adds a `flowchart TD` Mermaid decision diagram to the Storage section so candidates have a visual decision path for choosing between Hot, Cool, Cold, and Archive access tiers under exam conditions.

## Changes

- **docs/AZ-305_CheatSheet.md**: Added a `flowchart TD` diagram immediately after the access tier exam-tip callout in the Storage section. The diagram covers all four tiers (Hot/Cool/Cold/Archive) with minimum-retention constraints annotated on each edge, and includes a rehydration note on the Archive path — matching the pattern established by the Networking section decision flows.

## Testing

- `python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md` — validates all Mermaid blocks including the new flowchart; must exit 0.
- `npx markdownlint-cli2 "**/*.md"` — linting passes with no new violations.
- `pytest tests/ -v --cov=scripts --cov-fail-under=90` — existing test suite passes at or above 90% coverage; no new test code required for a documentation-only change.

Closes #193