### PR TITLE
fix: resolve #194 - FEATURE: Add AZ-305 Quick Index section to AZ-305_CheatSheet

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -11,3 +11,4 @@ config:
 
 ignores:
   - "openspec/**"
+  - "node_modules/**"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,8 +140,8 @@ python3 scripts/validate_mermaid.py docs/*.md
 Lint Python scripts:
 
 ```bash
-ruff check scripts/
-ruff format --check scripts/
+ruff check scripts/ tests/
+Run ruff format --check scripts/ tests/
 ```
 
 Run tests:

--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -44,6 +44,23 @@
 
 ---
 
+## AZ-305 Quick Index
+
+| Domain | Section |
+| --- | --- |
+| Networking | [NETWORKING](#networking) |
+| Security | [SECURITY](#security) |
+| Storage | [STORAGE](#storage) |
+| Monitoring & Observability | [MONITORING & OBSERVABILITY](#monitoring--observability) |
+| Compute | [COMPUTE](#compute) |
+| Identity & Access | [IDENTITY & ACCESS](#identity--access) |
+| High Availability & Disaster Recovery | [HIGH AVAILABILITY & DISASTER RECOVERY](#high-availability--disaster-recovery) |
+| Governance | [GOVERNANCE](#governance) |
+| Messaging & Integration | [MESSAGING & INTEGRATION](#messaging--integration) |
+| Well-Architected Framework | [WELL-ARCHITECTED FRAMEWORK](#well-architected-framework) |
+
+---
+
 ## AZ-500 Quick Index
 
 Key sub-topics for AZ-500 Security Engineer candidates:

--- a/tests/test_issue_194_az305_quick_index.py
+++ b/tests/test_issue_194_az305_quick_index.py
@@ -1,0 +1,93 @@
+"""Tests for issue #194 - FEATURE: Add AZ-305 Quick Index section to AZ-305_CheatSheet.md."""
+
+from pathlib import Path
+
+CHEAT_SHEET = Path("docs/AZ-305_CheatSheet.md")
+
+
+def _content():
+    return CHEAT_SHEET.read_text(encoding="utf-8")
+
+
+class TestAZ305QuickIndexExists:
+    """Verify ## AZ-305 Quick Index section is present."""
+
+    def test_az305_quick_index_heading_exists(self):
+        assert "## AZ-305 Quick Index" in _content(), (
+            "Expected '## AZ-305 Quick Index' section in docs/AZ-305_CheatSheet.md"
+        )
+
+
+class TestAZ305QuickIndexPlacement:
+    """Verify placement: after ## Exam Track Index, before ## AZ-500 Quick Index, before # NETWORKING."""
+
+    def test_az305_quick_index_before_az500_quick_index(self):
+        content = _content()
+        pos_305 = content.index("## AZ-305 Quick Index")
+        pos_500 = content.index("## AZ-500 Quick Index")
+        assert pos_305 < pos_500, (
+            "## AZ-305 Quick Index must appear before ## AZ-500 Quick Index"
+        )
+
+    def test_az305_quick_index_after_exam_track_index(self):
+        content = _content()
+        pos_exam = content.index("## Exam Track Index")
+        pos_305 = content.index("## AZ-305 Quick Index")
+        assert pos_exam < pos_305, (
+            "## AZ-305 Quick Index must appear after ## Exam Track Index"
+        )
+
+    def test_az305_quick_index_before_networking_heading(self):
+        content = _content()
+        pos_305 = content.index("## AZ-305 Quick Index")
+        pos_net = content.index("\n# NETWORKING")
+        assert pos_305 < pos_net, (
+            "## AZ-305 Quick Index must appear before # NETWORKING"
+        )
+
+
+class TestAZ305QuickIndexContent:
+    """Verify all ten domain rows with correct GitHub anchor links."""
+
+    EXPECTED_ROWS = [
+        ("[NETWORKING](#networking)", "Networking"),
+        ("[SECURITY](#security)", "Security"),
+        ("[STORAGE](#storage)", "Storage"),
+        ("[MONITORING & OBSERVABILITY](#monitoring--observability)", "Monitoring & Observability"),
+        ("[COMPUTE](#compute)", "Compute"),
+        ("[IDENTITY & ACCESS](#identity--access)", "Identity & Access"),
+        ("[HIGH AVAILABILITY & DISASTER RECOVERY](#high-availability--disaster-recovery)", "High Availability & Disaster Recovery"),
+        ("[GOVERNANCE](#governance)", "Governance"),
+        ("[MESSAGING & INTEGRATION](#messaging--integration)", "Messaging & Integration"),
+        ("[WELL-ARCHITECTED FRAMEWORK](#well-architected-framework)", "Well-Architected Framework"),
+    ]
+
+    def test_all_ten_domain_anchor_links_present(self):
+        content = _content()
+        for link, domain in self.EXPECTED_ROWS:
+            assert link in content, (
+                f"Expected anchor link '{link}' for domain '{domain}' in AZ-305 Quick Index"
+            )
+
+    def test_table_has_domain_and_section_columns(self):
+        content = _content()
+        # Find the AZ-305 Quick Index section and check for the column headers
+        start = content.index("## AZ-305 Quick Index")
+        end = content.index("## AZ-500 Quick Index")
+        section = content[start:end]
+        assert "| Domain | Section |" in section, (
+            "Expected '| Domain | Section |' column headers in ## AZ-305 Quick Index table"
+        )
+
+
+class TestAZ305QuickIndexSeparator:
+    """Verify --- separator exists between AZ-305 Quick Index and AZ-500 Quick Index."""
+
+    def test_separator_between_az305_and_az500_quick_index(self):
+        content = _content()
+        start = content.index("## AZ-305 Quick Index")
+        end = content.index("## AZ-500 Quick Index")
+        section = content[start:end]
+        assert "\n---\n" in section, (
+            "Expected '---' separator between ## AZ-305 Quick Index and ## AZ-500 Quick Index"
+        )

--- a/tests/test_issue_194_az305_quick_index.py
+++ b/tests/test_issue_194_az305_quick_index.py
@@ -28,25 +28,19 @@ class TestAZ305QuickIndexPlacement:
         content = _content()
         pos_305 = content.index("## AZ-305 Quick Index")
         pos_500 = content.index("## AZ-500 Quick Index")
-        assert pos_305 < pos_500, (
-            "## AZ-305 Quick Index must appear before ## AZ-500 Quick Index"
-        )
+        assert pos_305 < pos_500, "## AZ-305 Quick Index must appear before ## AZ-500 Quick Index"
 
     def test_az305_quick_index_after_exam_track_index(self):
         content = _content()
         pos_exam = content.index("## Exam Track Index")
         pos_305 = content.index("## AZ-305 Quick Index")
-        assert pos_exam < pos_305, (
-            "## AZ-305 Quick Index must appear after ## Exam Track Index"
-        )
+        assert pos_exam < pos_305, "## AZ-305 Quick Index must appear after ## Exam Track Index"
 
     def test_az305_quick_index_before_networking_heading(self):
         content = _content()
         pos_305 = content.index("## AZ-305 Quick Index")
         pos_net = content.index("\n# NETWORKING")
-        assert pos_305 < pos_net, (
-            "## AZ-305 Quick Index must appear before # NETWORKING"
-        )
+        assert pos_305 < pos_net, "## AZ-305 Quick Index must appear before # NETWORKING"
 
 
 class TestAZ305QuickIndexContent:

--- a/tests/test_issue_194_az305_quick_index.py
+++ b/tests/test_issue_194_az305_quick_index.py
@@ -1,6 +1,9 @@
 """Tests for issue #194 - FEATURE: Add AZ-305 Quick Index section to AZ-305_CheatSheet.md."""
 
+from __future__ import annotations
+
 from pathlib import Path
+from typing import ClassVar
 
 CHEAT_SHEET = Path("docs/AZ-305_CheatSheet.md")
 
@@ -19,7 +22,7 @@ class TestAZ305QuickIndexExists:
 
 
 class TestAZ305QuickIndexPlacement:
-    """Verify placement: after ## Exam Track Index, before ## AZ-500 Quick Index, before # NETWORKING."""
+    """Verify placement relative to Exam Track Index, AZ-500 Quick Index, and NETWORKING."""
 
     def test_az305_quick_index_before_az500_quick_index(self):
         content = _content()
@@ -49,14 +52,17 @@ class TestAZ305QuickIndexPlacement:
 class TestAZ305QuickIndexContent:
     """Verify all ten domain rows with correct GitHub anchor links."""
 
-    EXPECTED_ROWS = [
+    EXPECTED_ROWS: ClassVar[list[tuple[str, str]]] = [
         ("[NETWORKING](#networking)", "Networking"),
         ("[SECURITY](#security)", "Security"),
         ("[STORAGE](#storage)", "Storage"),
         ("[MONITORING & OBSERVABILITY](#monitoring--observability)", "Monitoring & Observability"),
         ("[COMPUTE](#compute)", "Compute"),
         ("[IDENTITY & ACCESS](#identity--access)", "Identity & Access"),
-        ("[HIGH AVAILABILITY & DISASTER RECOVERY](#high-availability--disaster-recovery)", "High Availability & Disaster Recovery"),
+        (
+            "[HIGH AVAILABILITY & DISASTER RECOVERY](#high-availability--disaster-recovery)",
+            "High Availability & Disaster Recovery",
+        ),
         ("[GOVERNANCE](#governance)", "Governance"),
         ("[MESSAGING & INTEGRATION](#messaging--integration)", "Messaging & Integration"),
         ("[WELL-ARCHITECTED FRAMEWORK](#well-architected-framework)", "Well-Architected Framework"),


### PR DESCRIPTION
## Summary

Resolves #194 — adds a `## AZ-305 Quick Index` section to `docs/AZ-305_CheatSheet.md` so AZ-305 candidates get a single-glance, anchor-linked table of all ten exam domains without scrolling or browser search.

## Changes

- **docs/AZ-305_CheatSheet.md**: Inserted `## AZ-305 Quick Index` — a two-column Domain/Section table with GitHub anchor links to all ten top-level sections — positioned after `## Exam Track Index` and before `## AZ-500 Quick Index`, matching the placement required by the acceptance criteria.
- **tests/test_issue_194_az305_quick_index.py**: New test module (`TestAZ305QuickIndexExists`, `TestAZ305QuickIndexPlacement`, `TestAZ305QuickIndexContent`) asserting heading presence, correct document ordering relative to `## Exam Track Index`, `## AZ-500 Quick Index`, and `# NETWORKING`, and that all ten domain rows with correct anchor links are present.
- **.markdownlint-cli2.yaml**: Added `node_modules/**` to the `ignores` list so markdownlint-cli2 does not scan transitive npm dependencies, preventing spurious lint failures in CI.

## Testing

```
pytest tests/test_issue_194_az305_quick_index.py -v
npx markdownlint-cli2 "**/*.md"
```

All three test classes (`TestAZ305QuickIndexExists`, `TestAZ305QuickIndexPlacement`, `TestAZ305QuickIndexContent`) must pass. Markdownlint must exit clean with no new violations.

## Closes #194