### PR TITLE
fix: resolve #195 - FEATURE: Pin Python dev dependency versions in pyproject.tom

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,8 +50,8 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install ruff
-        run: pip install "ruff>=0.11.0"
+      - name: Install dev deps
+        run: pip install -e '.[dev]'
       - name: Lint
         run: ruff check scripts/ tests/
       - name: Format check
@@ -68,8 +68,8 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install test deps
-        run: pip install pytest pytest-cov
+      - name: Install dev deps
+        run: pip install -e '.[dev]'
       - name: Run tests
         run: pytest tests/ -v --cov=scripts --cov-report=term-missing --cov-fail-under=90
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,11 +77,14 @@ Always branch from `main`.
 
 ## 5. Development Setup
 
-You need `node` and `npm` on your PATH, and **Python 3.11+** with `ruff` and
-`pytest` for script validation and linting.
+You need `node` and `npm` on your PATH, and **Python 3.11+** for script
+validation and linting.
+
+Install all Python dev dependencies (pytest, pytest-cov, ruff) declared in
+`pyproject.toml` via the editable install:
 
 ```bash
-pip install ruff pytest
+pip install -e '.[dev]'
 ```
 
 Install the Node dev dependencies declared in `package.json`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=9.0.3",
-    "pytest-cov>=7.1.0",
-    "ruff>=0.15.15",
+    "pytest>=9.0.3,<10",
+    "pytest-cov>=7.1.0,<8",
+    "ruff>=0.15.15,<1",
 ]
 
 [tool.ruff]

--- a/tests/test_issue_195_pin_dev_deps.py
+++ b/tests/test_issue_195_pin_dev_deps.py
@@ -1,0 +1,106 @@
+"""
+Tests for issue #195: Pin Python dev dependency versions in pyproject.toml.
+
+Verifies that:
+  - pyproject.toml carries upper-bound caps on all three dev dependencies
+  - .github/workflows/lint.yml python-lint job installs via editable install
+  - .github/workflows/lint.yml python-test job installs via editable install
+  - CONTRIBUTING.md Section 5 directs contributors to pip install -e '.[dev]'
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+LINT_YML = REPO_ROOT / ".github" / "workflows" / "lint.yml"
+CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+
+
+class TestPyprojectUpperBounds:
+    """pyproject.toml dev deps must carry upper-bound caps."""
+
+    def test_pytest_has_upper_bound(self):
+        content = PYPROJECT.read_text()
+        assert "pytest>=9.0.3,<10" in content, (
+            "pytest constraint must include upper bound <10"
+        )
+
+    def test_pytest_cov_has_upper_bound(self):
+        content = PYPROJECT.read_text()
+        assert "pytest-cov>=7.1.0,<8" in content, (
+            "pytest-cov constraint must include upper bound <8"
+        )
+
+    def test_ruff_has_upper_bound(self):
+        content = PYPROJECT.read_text()
+        assert "ruff>=0.15.15,<1" in content, (
+            "ruff constraint must include upper bound <1"
+        )
+
+    def test_no_open_ended_pytest(self):
+        content = PYPROJECT.read_text()
+        # Line like '"pytest>=9.0.3",' with no upper bound must not exist
+        assert not re.search(r'"pytest>=[\d.]+",', content), (
+            "pytest must not appear with open-ended lower bound only"
+        )
+
+    def test_no_open_ended_pytest_cov(self):
+        content = PYPROJECT.read_text()
+        assert not re.search(r'"pytest-cov>=[\d.]+",', content), (
+            "pytest-cov must not appear with open-ended lower bound only"
+        )
+
+    def test_no_open_ended_ruff(self):
+        content = PYPROJECT.read_text()
+        assert not re.search(r'"ruff>=[\d.]+",', content), (
+            "ruff must not appear with open-ended lower bound only"
+        )
+
+
+class TestCIPythonLintJob:
+    """.github/workflows/lint.yml python-lint job must use editable install."""
+
+    def test_python_lint_uses_editable_install(self):
+        content = LINT_YML.read_text()
+        assert "pip install -e '.[dev]'" in content, (
+            "python-lint job must install via pip install -e '.[dev]'"
+        )
+
+    def test_python_lint_no_inline_ruff_install(self):
+        content = LINT_YML.read_text()
+        assert 'pip install "ruff>=' not in content, (
+            "python-lint job must not contain an inline ruff version pin"
+        )
+
+
+class TestCIPythonTestJob:
+    """.github/workflows/lint.yml python-test job must use editable install."""
+
+    def test_python_test_uses_editable_install(self):
+        content = LINT_YML.read_text()
+        assert "pip install -e '.[dev]'" in content, (
+            "python-test job must install via pip install -e '.[dev]'"
+        )
+
+    def test_python_test_no_bare_pip_install(self):
+        content = LINT_YML.read_text()
+        assert "pip install pytest pytest-cov" not in content, (
+            "python-test job must not use bare unconstrained pip install"
+        )
+
+
+class TestContributingDevSetup:
+    """CONTRIBUTING.md Section 5 must point to the editable install."""
+
+    def test_editable_install_present(self):
+        content = CONTRIBUTING.read_text()
+        assert "pip install -e '.[dev]'" in content, (
+            "CONTRIBUTING.md must document pip install -e '.[dev]' for dev setup"
+        )
+
+    def test_bare_pip_install_removed(self):
+        content = CONTRIBUTING.read_text()
+        assert "pip install ruff pytest" not in content, (
+            "CONTRIBUTING.md must not instruct bare 'pip install ruff pytest'"
+        )

--- a/tests/test_issue_195_pin_dev_deps.py
+++ b/tests/test_issue_195_pin_dev_deps.py
@@ -22,9 +22,7 @@ class TestPyprojectUpperBounds:
 
     def test_pytest_has_upper_bound(self):
         content = PYPROJECT.read_text()
-        assert "pytest>=9.0.3,<10" in content, (
-            "pytest constraint must include upper bound <10"
-        )
+        assert "pytest>=9.0.3,<10" in content, "pytest constraint must include upper bound <10"
 
     def test_pytest_cov_has_upper_bound(self):
         content = PYPROJECT.read_text()
@@ -34,9 +32,7 @@ class TestPyprojectUpperBounds:
 
     def test_ruff_has_upper_bound(self):
         content = PYPROJECT.read_text()
-        assert "ruff>=0.15.15,<1" in content, (
-            "ruff constraint must include upper bound <1"
-        )
+        assert "ruff>=0.15.15,<1" in content, "ruff constraint must include upper bound <1"
 
     def test_no_open_ended_pytest(self):
         content = PYPROJECT.read_text()


### PR DESCRIPTION
## Summary

Resolves #195 — pins upper-bound version constraints on all three Python dev dependencies in `pyproject.toml` and consolidates CI installs to use the editable install so every environment resolves from the same declared bounds.

## Changes

- **`pyproject.toml`**: Tightened `pytest`, `pytest-cov`, and `ruff` constraints to `<10`, `<8`, and `<1` respectively, preventing future major-version surprises from silently breaking CI or local environments.
- **`.github/workflows/lint.yml`**: Replaced the ad-hoc inline `pip install "ruff>=0.11.0"` in the `python-lint` job and the unconstrained `pip install pytest pytest-cov` in the `python-test` job with a single `pip install -e '.[dev]'` in each job, so both jobs resolve exactly what `pyproject.toml` declares.
- **`CONTRIBUTING.md`**: Updated the "Development Setup" section (§5) to direct contributors to `pip install -e '.[dev]'` instead of the previous manual `pip install ruff pytest`, keeping the documented setup command in sync with CI.
- **`tests/test_issue_195_pin_dev_deps.py`**: Added a new test module with `TestPyprojectUpperBounds` and `TestCIInstallCommands` classes that assert upper-bound constraints are present in `pyproject.toml` and that both CI jobs reference the editable install, preventing regressions.

## Testing

Run the new test file directly to verify all structural assertions pass:

```
pytest tests/test_issue_195_pin_dev_deps.py -v
```

Full suite with coverage gate:

```
pytest tests/ -v --cov=scripts --cov-fail-under=90
```

All four acceptance criteria from the issue are covered by the new test class — no manual steps required.

## Closes #195