### PR TITLE
fix: resolve #196 - FEATURE: Add structured Governance section decision flowchar

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -11,3 +11,4 @@ config:
 
 ignores:
   - "openspec/**"
+  - "node_modules/**"

--- a/docs/AZ-305_CheatSheet.md
+++ b/docs/AZ-305_CheatSheet.md
@@ -1062,6 +1062,24 @@ graph TD
 
 ---
 
+## Governance Enforcement Decision Flow
+
+```mermaid
+flowchart TD
+    A[Governance requirement?] -->|Enforce compliance rules / auto-remediate| B[Azure Policy]
+    A -->|Organise subscriptions + inherit controls| C[Management Groups]
+    A -->|Provision repeatable governed environment| D[Template Specs + Policy + RBAC]
+    A -->|Cap or alert on spend| E[Budgets + Cost Management]
+    D -->|Legacy environment uses Blueprints?| F[Migrate: Template Specs + Policy + RBAC\nBlueprints retired July 2026]
+```
+
+> **Exam tip:** When a question mentions enforcing a rule that blocks or auto-remediates
+> non-compliant resources across subscriptions, the answer is Azure Policy — not Locks
+> (which only prevent delete/write) and not Management Groups (which are the scope, not the
+> enforcement tool).
+
+---
+
 ## Cost Management
 
 | Tool | Purpose |

--- a/tests/test_issue_196_governance_decision_flow.py
+++ b/tests/test_issue_196_governance_decision_flow.py
@@ -160,5 +160,6 @@ class TestGovernanceDecisionFlowPlacement:
         assert idx_dep != -1, "Blueprints deprecation warning not found"
         assert idx_flow != -1, "Governance Enforcement Decision Flow subsection not found"
         assert idx_dep < idx_flow, (
-            "Governance Enforcement Decision Flow must appear after the Blueprints deprecation block"
+            "Governance Enforcement Decision Flow must appear after "
+            "the Blueprints deprecation block"
         )

--- a/tests/test_issue_196_governance_decision_flow.py
+++ b/tests/test_issue_196_governance_decision_flow.py
@@ -1,0 +1,164 @@
+"""Tests for issue #196 - FEATURE: Add structured Governance section decision flowchart.
+
+Verifies that:
+  - A '## Governance Enforcement Decision Flow' subsection exists in AZ-305_CheatSheet.md
+  - The subsection contains a flowchart TD Mermaid diagram
+  - All four primary decision branches are present in the diagram
+  - The fifth legacy-Blueprints migration branch is present
+  - An exam-tip callout follows the diagram covering Policy vs Locks vs Management Groups
+  - The subsection appears between the Blueprints deprecation block and ## Cost Management
+  - The diagram directive is exactly 'flowchart TD' (not 'graph TD')
+"""
+
+import pathlib
+import re
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+AZ305 = REPO_ROOT / "docs" / "AZ-305_CheatSheet.md"
+
+
+@pytest.fixture(scope="module")
+def az305_text():
+    return AZ305.read_text()
+
+
+@pytest.fixture(scope="module")
+def governance_section(az305_text):
+    """Extract the GOVERNANCE section text for narrower assertions."""
+    match = re.search(r"(# GOVERNANCE.*?)(?=\n# [A-Z])", az305_text, re.DOTALL)
+    assert match, "GOVERNANCE section not found in AZ-305_CheatSheet.md"
+    return match.group(1)
+
+
+class TestGovernanceDecisionFlowSubsectionExists:
+    """The '## Governance Enforcement Decision Flow' subsection must exist."""
+
+    def test_subsection_heading_present(self, governance_section):
+        assert "## Governance Enforcement Decision Flow" in governance_section
+
+    def test_subsection_uses_h2_not_h3(self, az305_text):
+        # Must be ## not ###
+        assert "## Governance Enforcement Decision Flow" in az305_text
+        assert "### Governance Enforcement Decision Flow" not in az305_text
+
+
+class TestGovernanceDecisionFlowDiagramDirective:
+    """The diagram must use 'flowchart TD', not 'graph TD'."""
+
+    def test_flowchart_td_directive_present(self, governance_section):
+        # Extract the decision-flow subsection specifically
+        match = re.search(
+            r"## Governance Enforcement Decision Flow(.*?)(?=\n## |\Z)",
+            governance_section,
+            re.DOTALL,
+        )
+        assert match, "Governance Enforcement Decision Flow subsection body not found"
+        body = match.group(1)
+        assert "flowchart TD" in body, "Diagram must use 'flowchart TD' directive"
+
+    def test_no_graph_td_in_decision_flow(self, governance_section):
+        match = re.search(
+            r"## Governance Enforcement Decision Flow(.*?)(?=\n## |\Z)",
+            governance_section,
+            re.DOTALL,
+        )
+        assert match
+        body = match.group(1)
+        assert "graph TD" not in body, "Decision flow must not use 'graph TD'"
+
+
+class TestGovernanceDecisionFlowBranches:
+    """All four decision branches must be present in the diagram."""
+
+    def _diagram_body(self, governance_section):
+        match = re.search(
+            r"## Governance Enforcement Decision Flow(.*?)(?=\n## |\Z)",
+            governance_section,
+            re.DOTALL,
+        )
+        assert match
+        return match.group(1)
+
+    def test_branch_azure_policy(self, governance_section):
+        body = self._diagram_body(governance_section)
+        assert "Azure Policy" in body, "Branch for Azure Policy must be present"
+
+    def test_branch_management_groups(self, governance_section):
+        body = self._diagram_body(governance_section)
+        assert "Management Groups" in body, "Branch for Management Groups must be present"
+
+    def test_branch_template_specs(self, governance_section):
+        body = self._diagram_body(governance_section)
+        assert "Template Specs" in body, "Branch for Template Specs must be present"
+
+    def test_branch_budgets_cost_management(self, governance_section):
+        body = self._diagram_body(governance_section)
+        assert "Budgets" in body and "Cost Management" in body, (
+            "Branch for Budgets + Cost Management must be present"
+        )
+
+    def test_branch_blueprints_migration(self, governance_section):
+        """Fifth branch: legacy Blueprints migration path."""
+        body = self._diagram_body(governance_section)
+        assert "Blueprints" in body, "Legacy Blueprints migration branch must be present"
+
+
+class TestGovernanceDecisionFlowExamTip:
+    """An exam-tip callout distinguishing Policy vs Locks vs Management Groups must follow."""
+
+    def test_exam_tip_present_after_diagram(self, governance_section):
+        match = re.search(
+            r"## Governance Enforcement Decision Flow(.*?)(?=\n## |\Z)",
+            governance_section,
+            re.DOTALL,
+        )
+        assert match
+        body = match.group(1)
+        assert "> **Exam tip:**" in body, (
+            "Exam tip callout must follow the Governance Enforcement Decision Flow diagram"
+        )
+
+    def test_exam_tip_mentions_locks(self, governance_section):
+        match = re.search(
+            r"## Governance Enforcement Decision Flow(.*?)(?=\n## |\Z)",
+            governance_section,
+            re.DOTALL,
+        )
+        assert match
+        body = match.group(1)
+        assert "Locks" in body, "Exam tip must clarify that Locks are not an enforcement tool"
+
+    def test_exam_tip_mentions_policy(self, governance_section):
+        match = re.search(
+            r"## Governance Enforcement Decision Flow(.*?)(?=\n## |\Z)",
+            governance_section,
+            re.DOTALL,
+        )
+        assert match
+        body = match.group(1)
+        # Azure Policy must appear in the exam-tip region (not just the diagram)
+        assert "Azure Policy" in body
+
+
+class TestGovernanceDecisionFlowPlacement:
+    """The new subsection must appear between the Blueprints block and ## Cost Management."""
+
+    def test_decision_flow_before_cost_management(self, governance_section):
+        idx_flow = governance_section.find("## Governance Enforcement Decision Flow")
+        idx_cost = governance_section.find("## Cost Management")
+        assert idx_flow != -1, "Governance Enforcement Decision Flow subsection not found"
+        assert idx_cost != -1, "Cost Management subsection not found"
+        assert idx_flow < idx_cost, (
+            "Governance Enforcement Decision Flow must appear before ## Cost Management"
+        )
+
+    def test_decision_flow_after_blueprints_deprecation(self, governance_section):
+        idx_dep = governance_section.find("Blueprints is retired")
+        idx_flow = governance_section.find("## Governance Enforcement Decision Flow")
+        assert idx_dep != -1, "Blueprints deprecation warning not found"
+        assert idx_flow != -1, "Governance Enforcement Decision Flow subsection not found"
+        assert idx_dep < idx_flow, (
+            "Governance Enforcement Decision Flow must appear after the Blueprints deprecation block"
+        )


### PR DESCRIPTION
## Summary

Resolves #196 — adds a `flowchart TD` decision diagram to the Governance section of the AZ-305 cheat sheet so candidates can quickly identify the correct enforcement mechanism (Policy, Management Groups, Template Specs, Budgets) from a scenario description.

## Changes

- **docs/AZ-305_CheatSheet.md**: Added `## Governance Enforcement Decision Flow` subsection containing a `flowchart TD` Mermaid diagram with five branches (Policy enforcement, Management Group scope, Template Specs + Policy + RBAC provisioning, Budgets/Cost Management spend cap, and a Blueprints migration branch). Followed immediately by an exam-tip callout distinguishing Azure Policy from Locks and Management Groups — placed between the existing Blueprints deprecation block and `## Cost Management`, per AGENTS.md placement convention.
- **tests/test_issue_196_governance_decision_flow.py**: New test module (165 lines) that asserts the subsection heading exists at `##` depth, the diagram uses `flowchart TD` (not `graph TD`), all four primary decision branches and the Blueprints migration branch are present, the exam-tip callout is included, and the subsection sits in the correct position relative to its neighbours.
- **.markdownlint-cli2.yaml**: Added `node_modules/**` to the `ignores` list to prevent markdownlint from scanning installed npm packages during local and CI runs.

## Testing

Run the full suite with coverage to confirm all acceptance criteria pass:

```
pytest tests/test_issue_196_governance_decision_flow.py -v
pytest tests/ -v --cov=scripts --cov-fail-under=90
python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md
npx markdownlint-cli2 "**/*.md"
```

The new test file covers: subsection heading presence, `##` vs `###` depth, `flowchart TD` directive, all five diagram branches, exam-tip callout content, and correct placement between the Blueprints block and `## Cost Management`.

## Closes #196