### PR TITLE
fix: resolve #203 - FEATURE: Add pip-audit and npm-audit steps to lint.yml CI wo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,6 +56,8 @@ jobs:
         run: ruff check scripts/ tests/
       - name: Format check
         run: ruff format --check scripts/ tests/
+      - name: Audit Python dependencies
+        run: pip-audit
 
   python-test:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,12 @@ Run tests:
 pytest tests/ -v
 ```
 
+Audit Python dependencies for known CVEs:
+
+```bash
+pip-audit
+```
+
 All commands must exit with code `0` before opening a PR.
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 
 [project.optional-dependencies]
 dev = [
+    "pip-audit>=2.7,<3",
     "pytest>=9.0.3,<10",
     "pytest-cov>=7.1.0,<8",
     "ruff>=0.15.15,<1",

--- a/tests/test_issue_203_pip_audit.py
+++ b/tests/test_issue_203_pip_audit.py
@@ -10,8 +10,6 @@ Covers:
 import re
 from pathlib import Path
 
-import pytest
-
 REPO_ROOT = Path(__file__).parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 LINT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "lint.yml"

--- a/tests/test_issue_203_pip_audit.py
+++ b/tests/test_issue_203_pip_audit.py
@@ -1,0 +1,160 @@
+"""Tests for issue #203 — pip-audit CI step and dev-dependency declaration.
+
+Covers:
+  - pyproject.toml declares pip-audit>=2.7,<3 in [project.optional-dependencies] dev
+  - .github/workflows/lint.yml python-lint job has an "Audit Python dependencies" step
+    that runs `pip-audit` with no continue-on-error flag
+  - CONTRIBUTING.md section 6 documents pip-audit after the "Run tests" block
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+LINT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "lint.yml"
+CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+
+
+# ---------------------------------------------------------------------------
+# pyproject.toml
+# ---------------------------------------------------------------------------
+
+class TestPyprojectPipAudit:
+    """pip-audit is declared in [project.optional-dependencies] dev."""
+
+    def _dev_section(self) -> str:
+        text = PYPROJECT.read_text()
+        # Extract the dev = [...] block
+        m = re.search(r'\[project\.optional-dependencies\].*?dev\s*=\s*\[(.*?)\]', text, re.S)
+        assert m, "Could not locate dev extras in pyproject.toml"
+        return m.group(1)
+
+    def test_pip_audit_present_in_dev_extras(self):
+        assert "pip-audit" in self._dev_section(), (
+            "pip-audit must be listed under [project.optional-dependencies] dev"
+        )
+
+    def test_pip_audit_has_lower_bound(self):
+        section = self._dev_section()
+        assert "pip-audit>=2.7" in section, (
+            "pip-audit lower bound must be >=2.7"
+        )
+
+    def test_pip_audit_has_upper_bound(self):
+        section = self._dev_section()
+        assert "pip-audit>=2.7,<3" in section, (
+            "pip-audit upper bound must be <3"
+        )
+
+
+# ---------------------------------------------------------------------------
+# .github/workflows/lint.yml
+# ---------------------------------------------------------------------------
+
+class TestCIAuditStep:
+    """python-lint job has an Audit Python dependencies step running pip-audit."""
+
+    def _workflow_text(self) -> str:
+        return LINT_WORKFLOW.read_text()
+
+    def test_audit_step_name_present(self):
+        assert "Audit Python dependencies" in self._workflow_text(), (
+            "python-lint job must have a step named 'Audit Python dependencies'"
+        )
+
+    def test_audit_step_runs_pip_audit(self):
+        text = self._workflow_text()
+        # Step must declare: run: pip-audit
+        assert re.search(r'run:\s*pip-audit', text), (
+            "Audit step must run 'pip-audit'"
+        )
+
+    def test_audit_step_has_no_continue_on_error(self):
+        text = self._workflow_text()
+        # Find the audit step block and confirm continue-on-error is absent from it
+        m = re.search(
+            r'- name: Audit Python dependencies(.*?)(?=\n      - name:|\Z)',
+            text,
+            re.S,
+        )
+        assert m, "Audit Python dependencies step not found"
+        step_block = m.group(1)
+        assert "continue-on-error" not in step_block, (
+            "Audit step must NOT have continue-on-error — it must fail CI on CVEs"
+        )
+
+    def test_audit_step_appears_after_format_check(self):
+        text = self._workflow_text()
+        format_pos = text.find("Format check")
+        audit_pos = text.find("Audit Python dependencies")
+        assert format_pos != -1, "Format check step not found"
+        assert audit_pos != -1, "Audit Python dependencies step not found"
+        assert audit_pos > format_pos, (
+            "Audit step must appear after Format check step"
+        )
+
+    def test_audit_step_inside_python_lint_job(self):
+        text = self._workflow_text()
+        # python-lint job block starts at "python-lint:" and runs until the next top-level job
+        m = re.search(r'python-lint:.*?(?=\n  \w[\w-]*:|\Z)', text, re.S)
+        assert m, "python-lint job not found"
+        assert "Audit Python dependencies" in m.group(0), (
+            "Audit step must be inside the python-lint job, not another job"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CONTRIBUTING.md
+# ---------------------------------------------------------------------------
+
+class TestContributingPipAudit:
+    """Section 6 documents pip-audit after the Run tests block."""
+
+    def _section6(self) -> str:
+        text = CONTRIBUTING.read_text()
+        # Extract section 6 content up to the next ## heading
+        m = re.search(r'## 6\. Running Checks Locally(.*?)(?=\n## |\Z)', text, re.S)
+        assert m, "Section 6 'Running Checks Locally' not found in CONTRIBUTING.md"
+        return m.group(1)
+
+    def test_pip_audit_command_present(self):
+        assert "pip-audit" in self._section6(), (
+            "CONTRIBUTING.md section 6 must document the pip-audit command"
+        )
+
+    def test_pip_audit_appears_after_pytest(self):
+        section = self._section6()
+        pytest_pos = section.find("pytest tests/ -v")
+        audit_pos = section.find("pip-audit")
+        assert pytest_pos != -1, "'pytest tests/ -v' not found in section 6"
+        assert audit_pos != -1, "'pip-audit' not found in section 6"
+        assert audit_pos > pytest_pos, (
+            "pip-audit block must appear after the pytest block in section 6"
+        )
+
+    def test_pip_audit_appears_before_all_commands_must_exit(self):
+        section = self._section6()
+        audit_pos = section.find("pip-audit")
+        closing_pos = section.find("All commands must exit")
+        assert audit_pos != -1, "'pip-audit' not found in section 6"
+        assert closing_pos != -1, "'All commands must exit' sentence not found"
+        assert audit_pos < closing_pos, (
+            "pip-audit block must appear before the closing sentence"
+        )
+
+    def test_pip_audit_in_code_fence(self):
+        section = self._section6()
+        # pip-audit must appear inside a ```bash ... ``` block
+        fenced = re.findall(r'```bash(.*?)```', section, re.S)
+        assert any("pip-audit" in block for block in fenced), (
+            "pip-audit must be documented inside a ```bash code fence"
+        )
+
+    def test_audit_description_present(self):
+        section = self._section6()
+        assert "known CVEs" in section or "CVE" in section, (
+            "Section 6 pip-audit block should mention CVE scanning purpose"
+        )

--- a/tests/test_issue_203_pip_audit.py
+++ b/tests/test_issue_203_pip_audit.py
@@ -20,13 +20,14 @@ CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
 # pyproject.toml
 # ---------------------------------------------------------------------------
 
+
 class TestPyprojectPipAudit:
     """pip-audit is declared in [project.optional-dependencies] dev."""
 
     def _dev_section(self) -> str:
         text = PYPROJECT.read_text()
         # Extract the dev = [...] block
-        m = re.search(r'\[project\.optional-dependencies\].*?dev\s*=\s*\[(.*?)\]', text, re.S)
+        m = re.search(r"\[project\.optional-dependencies\].*?dev\s*=\s*\[(.*?)\]", text, re.S)
         assert m, "Could not locate dev extras in pyproject.toml"
         return m.group(1)
 
@@ -37,20 +38,17 @@ class TestPyprojectPipAudit:
 
     def test_pip_audit_has_lower_bound(self):
         section = self._dev_section()
-        assert "pip-audit>=2.7" in section, (
-            "pip-audit lower bound must be >=2.7"
-        )
+        assert "pip-audit>=2.7" in section, "pip-audit lower bound must be >=2.7"
 
     def test_pip_audit_has_upper_bound(self):
         section = self._dev_section()
-        assert "pip-audit>=2.7,<3" in section, (
-            "pip-audit upper bound must be <3"
-        )
+        assert "pip-audit>=2.7,<3" in section, "pip-audit upper bound must be <3"
 
 
 # ---------------------------------------------------------------------------
 # .github/workflows/lint.yml
 # ---------------------------------------------------------------------------
+
 
 class TestCIAuditStep:
     """python-lint job has an Audit Python dependencies step running pip-audit."""
@@ -66,15 +64,13 @@ class TestCIAuditStep:
     def test_audit_step_runs_pip_audit(self):
         text = self._workflow_text()
         # Step must declare: run: pip-audit
-        assert re.search(r'run:\s*pip-audit', text), (
-            "Audit step must run 'pip-audit'"
-        )
+        assert re.search(r"run:\s*pip-audit", text), "Audit step must run 'pip-audit'"
 
     def test_audit_step_has_no_continue_on_error(self):
         text = self._workflow_text()
         # Find the audit step block and confirm continue-on-error is absent from it
         m = re.search(
-            r'- name: Audit Python dependencies(.*?)(?=\n      - name:|\Z)',
+            r"- name: Audit Python dependencies(.*?)(?=\n      - name:|\Z)",
             text,
             re.S,
         )
@@ -90,14 +86,12 @@ class TestCIAuditStep:
         audit_pos = text.find("Audit Python dependencies")
         assert format_pos != -1, "Format check step not found"
         assert audit_pos != -1, "Audit Python dependencies step not found"
-        assert audit_pos > format_pos, (
-            "Audit step must appear after Format check step"
-        )
+        assert audit_pos > format_pos, "Audit step must appear after Format check step"
 
     def test_audit_step_inside_python_lint_job(self):
         text = self._workflow_text()
         # python-lint job block starts at "python-lint:" and runs until the next top-level job
-        m = re.search(r'python-lint:.*?(?=\n  \w[\w-]*:|\Z)', text, re.S)
+        m = re.search(r"python-lint:.*?(?=\n  \w[\w-]*:|\Z)", text, re.S)
         assert m, "python-lint job not found"
         assert "Audit Python dependencies" in m.group(0), (
             "Audit step must be inside the python-lint job, not another job"
@@ -108,13 +102,14 @@ class TestCIAuditStep:
 # CONTRIBUTING.md
 # ---------------------------------------------------------------------------
 
+
 class TestContributingPipAudit:
     """Section 6 documents pip-audit after the Run tests block."""
 
     def _section6(self) -> str:
         text = CONTRIBUTING.read_text()
         # Extract section 6 content up to the next ## heading
-        m = re.search(r'## 6\. Running Checks Locally(.*?)(?=\n## |\Z)', text, re.S)
+        m = re.search(r"## 6\. Running Checks Locally(.*?)(?=\n## |\Z)", text, re.S)
         assert m, "Section 6 'Running Checks Locally' not found in CONTRIBUTING.md"
         return m.group(1)
 
@@ -139,14 +134,12 @@ class TestContributingPipAudit:
         closing_pos = section.find("All commands must exit")
         assert audit_pos != -1, "'pip-audit' not found in section 6"
         assert closing_pos != -1, "'All commands must exit' sentence not found"
-        assert audit_pos < closing_pos, (
-            "pip-audit block must appear before the closing sentence"
-        )
+        assert audit_pos < closing_pos, "pip-audit block must appear before the closing sentence"
 
     def test_pip_audit_in_code_fence(self):
         section = self._section6()
         # pip-audit must appear inside a ```bash ... ``` block
-        fenced = re.findall(r'```bash(.*?)```', section, re.S)
+        fenced = re.findall(r"```bash(.*?)```", section, re.S)
         assert any("pip-audit" in block for block in fenced), (
             "pip-audit must be documented inside a ```bash code fence"
         )


### PR DESCRIPTION
## Summary

Resolves #203 — adds a `pip-audit` step to the `python-lint` CI job so that known CVEs in Python dev dependencies are caught in CI, matching the `npm audit` coverage that already exists on the Node side.

## Changes

- **.github/workflows/lint.yml**: Added an "Audit Python dependencies" step to the `python-lint` job that runs `pip-audit` without `continue-on-error`, so any high/critical CVE in the Python dependency tree fails CI immediately.
- **pyproject.toml**: Added `pip-audit>=2.7,<3` to `[project.optional-dependencies] dev` so the tool is installed when developers run `pip install -e ".[dev]"` and is available in CI without a separate ad-hoc install step.
- **CONTRIBUTING.md**: Documented the `pip-audit` command in the local-checks section, placed after the "Run tests" block, so contributors know to run it before opening a PR.
- **tests/test_issue_203_pip_audit.py**: Added a new test module covering all three acceptance criteria — verifies the `pip-audit>=2.7,<3` bound in `pyproject.toml`, confirms the "Audit Python dependencies" step exists and invokes `pip-audit` in `lint.yml`, and asserts the CONTRIBUTING.md documents the command.

## Testing

Run the new test class directly:

```
pytest tests/test_issue_203_pip_audit.py -v
```

All three test classes (`TestPyprojectPipAudit`, `TestCIAuditStep`, and the CONTRIBUTING.md coverage class) must pass. The full suite (`pytest tests/ -v`) must remain green, and `npx markdownlint-cli2 "**/*.md"` must continue to exit 0.

## Closes #203