### PR TITLE
Fix/issue 164 feature add az 700 quick index section to az 305 c

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,128 @@
+# DewaldOosthuizen/azure_cheat_sheets
+
+Quick-reference study notes for Azure architecture decisions, aimed primarily
+at candidates preparing for AZ-305: Designing Microsoft Azure Infrastructure
+Solutions. The content focuses on service selection, architectural trade-offs,
+and decision reasoning — not step-by-step walkthroughs or portal labs.
+
+## Repository Structure
+
+```
+docs/cheat_sheets/AZ-305.md        — AZ-305 architect-focused cheat sheet
+docs/cheat_sheets/AZ-104.md        — AZ-104 administrator-focused cheat sheet
+docs/diagrams/<section>/*.mmd       — standalone Mermaid diagram sources (one per file)
+mkdocs.yml                          — MkDocs Material site config
+```
+
+The cheat sheets reference diagram files via PyMdown Snippets:
+
+```text
+```mermaid
+--8<-- "diagrams/<section>/<exam>-<slug>.mmd"
+```
+
+```
+
+MkDocs (Material theme) expands the snippets and renders Mermaid in the browser.
+Run `make docs-serve` to preview locally, `make docs-build` for a strict build.
+
+The cheat sheet is organized into ten top-level sections:
+dsf
+1. Networking
+2. Security
+3. Storage
+4. Monitoring & Observability
+5. Compute
+6. Identity & Access
+7. High Availability & Disaster Recovery
+8. Governance
+9. Messaging & Integration
+10. Well-Architected Framework
+
+## Exam Overlap
+
+| Exam   | Focus         | Relevant Sections |
+|--------|---------------|-------------------|
+| AZ-900 | Fundamentals  | Networking (overview), Storage, Compute, Identity & Access (Entra basics) |
+| AZ-104 | Administrator | All sections — administrator-level depth on RBAC, Networking, HA & DR; Messaging & Integration (partial — Service Bus, Event Hub namespace admin) |
+| AZ-305 | Architect     | All sections including Messaging & Integration and Well-Architected Framework |
+| AZ-500 | Security Engineer | Security (full), Identity & Access (full), Networking (partial), Monitoring & Observability (partial), Governance (partial) |
+| AZ-700 | Network Engineer | Networking (full), High Availability & Disaster Recovery (partial) |
+
+## Orientation for AI Agents
+
+This is a documentation-focused repository. All primary content lives in
+docs/cheat_sheets/AZ-305.md and docs/cheat_sheets/AZ-104.md.
+
+The repository includes a Makefile and Python/Node dev tooling for validation
+and CI. Run `make install` once after cloning to create the `.venv` and install
+all dependencies.
+
+When asked to add or update content:
+
+- Keep explanations concise and comparison-oriented.
+- Section headings: top-level domain names in ALL CAPS (`# NETWORKING`).
+  Sub-topics as `##`. Do not use Title Case for top-level section headings.
+- Prefer tables when comparing Azure services, tiers, or design options.
+  Use these column templates:
+
+  Networking / compute services:
+  | Service | Layer | Scope | Use Case | Key Feature |
+
+  Data / storage services:
+  | Service | Type | Best For | Key Feature |
+
+  Consistency columns (always present): Service, Key Feature.
+  Do not add free-form columns not in the template above.
+
+- Use short exam-tip callouts only when they clarify a likely decision point.
+  Format: place the callout immediately after the relevant table, using:
+
+  > **Exam tip:** Choose Azure Front Door when the requirement mentions
+  > global HTTP load balancing, WAF, or SSL offload at the edge.
+
+  Do not use plain blockquotes, bold sentences, or note/warning admonitions
+  for exam tips.
+
+- For retired, retiring, or superseded services, use a deprecation callout
+  instead of an exam-tip. See the [Deprecation warnings](CONTRIBUTING.md#10-deprecation-warnings)
+  section in CONTRIBUTING.md for the required format.
+
+- Use Mermaid diagrams for branching decision flows. Choose the directive by
+  purpose:
+
+  | Purpose                        | Directive       |
+  |--------------------------------|-----------------|
+  | Decision flows (if/else trees) | flowchart TD    |
+  | Hierarchy / ecosystem maps     | graph TD        |
+  | Connectivity / network paths   | graph LR        |
+
+  Example decision flow:
+
+  ```mermaid
+  flowchart TD
+      A[Need load balancing?] -->|Global HTTP| B[Azure Front Door]
+      A -->|Regional TCP/UDP| C[Azure Load Balancer]
+  ```
+
+- Do not document features or claims not already reflected in the content.
+- Other types of Mermaid diagrams may be used where it makes sense
+
+For pull requests, scope changes to one improvement area, explain what section
+changed and why it improves the cheat sheet for readers, and verify that
+Markdown and Mermaid blocks render cleanly on GitHub.
+Run `make install` once after cloning, then `make ci` before opening a PR — it
+replicates the full CI pipeline (markdownlint, Mermaid validation, ruff lint +
+format check, pytest with coverage).
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming, commit style, local
+checks, content conventions, and the PR checklist.
+
+## Mermaid Diagrams
+
+GitHub renders Mermaid natively. For local preview, install the
+"Markdown Preview Mermaid Support" extension in VS Code.
+
+## License
+
+GPL-3.0 — see LICENSE.

--- a/docs/cheat_sheets/AZ-305.md
+++ b/docs/cheat_sheets/AZ-305.md
@@ -71,6 +71,19 @@ Key sub-topics for AZ-500 Security Engineer candidates:
 
 ---
 
+## AZ-700 Quick Index
+
+Key sub-topics for AZ-700 Network Engineer candidates:
+
+- [Load Balancers](#load-balancers)
+- [Virtual Networks (VNet) — Peering, ExpressRoute, VPN Gateway](#virtual-networks-vnet)
+- [Network Security — NSG, ASG, Azure Firewall, DDoS](#network-security)
+- [Private Endpoint & Service Endpoint](#virtual-networks-vnet)
+- [Connectivity Patterns — Hub-Spoke, Virtual WAN](#connectivity-patterns)
+- [High Availability & Disaster Recovery](#high-availability--disaster-recovery)
+
+---
+
 # NETWORKING
 
 > Also relevant for: **AZ-900** (foundational networking concepts) and **AZ-104**
@@ -157,6 +170,11 @@ Key sub-topics for AZ-500 Security Engineer candidates:
 --8<-- "diagrams/networking/az305-virtual-networks-vnet.mmd"
 ```
 
+> **Exam tip (AZ-700):** Prefer ExpressRoute over VPN Gateway when the requirement
+> mentions dedicated bandwidth, consistent latency SLAs, or compliance mandates that
+> prohibit public-internet traversal. VPN Gateway (IPSec) is cost-effective for
+> smaller branch offices or when ExpressRoute is unavailable in the region.
+
 ## DNS
 
 | Service | Layer | Scope | Use Case | Key Feature |
@@ -177,6 +195,11 @@ Key sub-topics for AZ-500 Security Engineer candidates:
 > **Exam tip:** Use ASGs when NSG rules would otherwise require explicit IP lists for
 > multi-tier workloads. ASGs do not replace NSGs — they are used as dynamic address
 > groups inside NSG rules.
+
+> **Exam tip (AZ-700):** For AZ-700, know that NSGs operate at subnet or NIC level
+> (L3/L4, 5-tuple), while Azure Firewall operates at the hub VNet level (L3–L7,
+> FQDN-aware). Apply NSGs for micro-segmentation within a spoke; use Azure Firewall
+> for centralised east-west and north-south inspection across the hub-spoke topology.
 
 ### DDoS Protection Tiers
 
@@ -214,6 +237,12 @@ Key sub-topics for AZ-500 Security Engineer candidates:
 > with FQDN rules and threat intelligence; NVA = third-party deep inspection.
 > DDoS Protection Standard (not Basic) is required when the question mentions
 > SLA-backed mitigation, telemetry, or cost protection for volumetric attacks.
+
+> **Exam tip (AZ-700):** For AZ-700, Private Endpoint requires DNS integration —
+> the private DNS zone (e.g. privatelink.blob.core.windows.net) must be linked to
+> every VNet that needs to resolve the private IP. Forgetting the DNS link is the
+> most common misconfiguration; without it, the public FQDN resolves to the public
+> IP even when the endpoint exists.
 
 ## Content Delivery (CDN)
 

--- a/tests/test_issue_az700_quick_index.py
+++ b/tests/test_issue_az700_quick_index.py
@@ -1,0 +1,28 @@
+"""Tests for issue #164 — FEATURE: Add AZ-700 Quick Index section to AZ-305_CheatSheet.md."""
+
+from pathlib import Path
+
+CHEAT_SHEET = Path("docs/cheat_sheets/AZ-305.md")
+
+
+def _content():
+    return CHEAT_SHEET.read_text(encoding="utf-8")
+
+
+class TestAZ700QuickIndex:
+    """Verify AZ-700 Quick Index section exists."""
+
+    def test_az700_quick_index_section_exists(self):
+        assert "## AZ-700 Quick Index" in _content(), (
+            "Expected '## AZ-700 Quick Index' section in docs/cheat_sheets/AZ-305.md"
+        )
+
+
+class TestAZ700ExamTips:
+    """Verify at least 3 AZ-700 exam tip callouts exist."""
+
+    def test_at_least_three_az700_exam_tips(self):
+        count = _content().count("> **Exam tip (AZ-700):**")
+        assert count >= 3, (
+            f"Expected at least 3 occurrences of '> **Exam tip (AZ-700):**', found {count}"
+        )

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -391,8 +391,8 @@ class TestTraversalGuard:
         A naive startswith check would pass because the path string starts with
         the root string.  Path.is_relative_to() correctly rejects it.
         """
+        import tempfile
         from pathlib import Path
-        import tempfile, os
 
         with tempfile.TemporaryDirectory() as tmp:
             # Create two sibling directories whose names share a prefix.

--- a/tests/test_validate_mermaid.py
+++ b/tests/test_validate_mermaid.py
@@ -397,7 +397,7 @@ class TestTraversalGuard:
         with tempfile.TemporaryDirectory() as tmp:
             # Create two sibling directories whose names share a prefix.
             repo_root = Path(tmp) / "fake-repo-root"
-            sibling   = Path(tmp) / "fake-repo-root-extra"
+            sibling = Path(tmp) / "fake-repo-root-extra"
             repo_root.mkdir()
             sibling.mkdir()
             outside_file = sibling / "file.md"


### PR DESCRIPTION
This pull request adds a new "AZ-700 Quick Index" section and targeted exam tips for AZ-700 Network Engineer candidates to the `AZ-305.md` cheat sheet, along with corresponding tests to ensure these additions are present and correct. The changes enhance the resource for users preparing for the AZ-700 exam by providing focused navigation and practical guidance, and introduce automated tests to maintain this content.

Content additions for AZ-700:

* Added a "## AZ-700 Quick Index" section at the top of `docs/cheat_sheets/AZ-305.md`, listing key networking sub-topics relevant to AZ-700 candidates for quick navigation.
* Inserted at least three "Exam tip (AZ-700)" callouts throughout the networking sections, providing practical advice on ExpressRoute vs. VPN Gateway, NSG vs. Azure Firewall use, and Private Endpoint DNS integration. [[1]](diffhunk://#diff-11b108a0597d19e1d71a0e0572edb452f2df37c1acbcf9cc3fa44330581cc11fR173-R177) [[2]](diffhunk://#diff-11b108a0597d19e1d71a0e0572edb452f2df37c1acbcf9cc3fa44330581cc11fR199-R203) [[3]](diffhunk://#diff-11b108a0597d19e1d71a0e0572edb452f2df37c1acbcf9cc3fa44330581cc11fR241-R246)

Testing improvements:

* Added `tests/test_issue_az700_quick_index.py` to verify the presence of the AZ-700 Quick Index section and at least three AZ-700 exam tips in the cheat sheet.

Minor code cleanup:

* Cleaned up import ordering in `tests/test_validate_mermaid.py` for clarity and style consistency.