### PR TITLE
fix: resolve #227 - FEATURE: Fix stale CI badge URL in README.md and correct mis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tech Cheat Sheets And Notes
 
-[![Lint](https://github.com/DewaldOosthuizen/azure_cheat_sheets/actions/workflows/lint.yml/badge.svg)](https://github.com/DewaldOosthuizen/azure_cheat_sheets/actions/workflows/lint.yml)
+[![Lint](https://github.com/DewaldOosthuizen/tech-cheat-sheets-and-notes/actions/workflows/lint.yml/badge.svg)](https://github.com/DewaldOosthuizen/tech-cheat-sheets-and-notes/actions/workflows/lint.yml)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/paypalme/DewaldOosthuizen1)
 
 You can view the live site at [![Live Site](https://img.shields.io/badge/Live%20Site-tech--cheat--sheets--and--notes.vercel.app-black?logo=vercel&logoColor=white)](https://tech-cheat-sheets-and-notes.vercel.app)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,9 +2,9 @@ site_name: Tech Cheat Sheets
 site_description: >-
   Quick-reference study notes for tech certifications and architecture decisions.
   Currently focused on Microsoft Azure, organised by domain.
-site_url: https://tech-cheat-sheets.vercel.app/
-repo_name: DewaldOosthuizen/tech-cheat-sheets
-repo_url: https://github.com/DewaldOosthuizen/tech-cheat-sheets
+site_url: https://tech-cheat-sheets-and-notes.vercel.app/
+repo_name: DewaldOosthuizen/tech-cheat-sheets-and-notes
+repo_url: https://github.com/DewaldOosthuizen/tech-cheat-sheets-and-notes
 
 docs_dir: docs
 site_dir: site

--- a/tests/test_issue_227.py
+++ b/tests/test_issue_227.py
@@ -84,13 +84,17 @@ class TestMkdocsUrls:
         )
 
     def test_stale_repo_name_absent(self):
+        # Must check full YAML line — the stale slug is a substring of the correct one.
         content = MKDOCS.read_text()
-        assert STALE_REPO_NAME not in content, (
-            f"mkdocs.yml must not contain stale repo_name '{STALE_REPO_NAME}'"
+        stale_line = f"repo_name: {STALE_REPO_NAME}\n"
+        assert stale_line not in content, (
+            f"mkdocs.yml must not contain stale repo_name line '{stale_line.strip()}'"
         )
 
     def test_stale_repo_url_absent(self):
+        # Must check full YAML line — the stale URL is a substring of the correct one.
         content = MKDOCS.read_text()
-        assert STALE_REPO_URL not in content, (
-            f"mkdocs.yml must not contain stale repo_url '{STALE_REPO_URL}'"
+        stale_line = f"repo_url: {STALE_REPO_URL}\n"
+        assert stale_line not in content, (
+            f"mkdocs.yml must not contain stale repo_url line '{stale_line.strip()}'"
         )

--- a/tests/test_issue_227.py
+++ b/tests/test_issue_227.py
@@ -35,9 +35,7 @@ class TestReadmeBadgeUrl:
             "https://github.com/DewaldOosthuizen/tech-cheat-sheets-and-notes"
             "/actions/workflows/lint.yml/badge.svg"
         )
-        assert expected in content, (
-            f"README.md badge image URL must contain '{expected}'"
-        )
+        assert expected in content, f"README.md badge image URL must contain '{expected}'"
 
     def test_badge_anchor_href_is_current(self):
         content = README.read_text()
@@ -45,9 +43,7 @@ class TestReadmeBadgeUrl:
             "https://github.com/DewaldOosthuizen/tech-cheat-sheets-and-notes"
             "/actions/workflows/lint.yml)"
         )
-        assert expected in content, (
-            f"README.md badge anchor href must contain '{expected}'"
-        )
+        assert expected in content, f"README.md badge anchor href must contain '{expected}'"
 
     def test_stale_repo_slug_absent_from_readme(self):
         content = README.read_text()

--- a/tests/test_issue_227.py
+++ b/tests/test_issue_227.py
@@ -1,0 +1,96 @@
+"""Regression tests for issue #227.
+
+Verifies that:
+  - README.md badge URL uses the current repository slug (tech-cheat-sheets-and-notes)
+  - README.md badge anchor href uses the current repository slug
+  - mkdocs.yml site_url points to the current Vercel site
+  - mkdocs.yml repo_name uses the current repository slug
+  - mkdocs.yml repo_url uses the current repository slug
+  - None of the stale/old slugs remain in either file
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+
+README = REPO_ROOT / "README.md"
+MKDOCS = REPO_ROOT / "mkdocs.yml"
+
+STALE_REPO_SLUG = "DewaldOosthuizen/azure_cheat_sheets"
+STALE_SITE_URL = "https://tech-cheat-sheets.vercel.app/"
+STALE_REPO_NAME = "DewaldOosthuizen/tech-cheat-sheets"
+STALE_REPO_URL = "https://github.com/DewaldOosthuizen/tech-cheat-sheets"
+
+CORRECT_REPO_SLUG = "DewaldOosthuizen/tech-cheat-sheets-and-notes"
+CORRECT_SITE_URL = "https://tech-cheat-sheets-and-notes.vercel.app/"
+CORRECT_REPO_URL = "https://github.com/DewaldOosthuizen/tech-cheat-sheets-and-notes"
+
+
+class TestReadmeBadgeUrl:
+    """README.md — CI badge image and anchor href must reference the live repo."""
+
+    def test_badge_image_url_is_current(self):
+        content = README.read_text()
+        expected = (
+            "https://github.com/DewaldOosthuizen/tech-cheat-sheets-and-notes"
+            "/actions/workflows/lint.yml/badge.svg"
+        )
+        assert expected in content, (
+            f"README.md badge image URL must contain '{expected}'"
+        )
+
+    def test_badge_anchor_href_is_current(self):
+        content = README.read_text()
+        expected = (
+            "https://github.com/DewaldOosthuizen/tech-cheat-sheets-and-notes"
+            "/actions/workflows/lint.yml)"
+        )
+        assert expected in content, (
+            f"README.md badge anchor href must contain '{expected}'"
+        )
+
+    def test_stale_repo_slug_absent_from_readme(self):
+        content = README.read_text()
+        assert STALE_REPO_SLUG not in content, (
+            f"README.md must not reference stale slug '{STALE_REPO_SLUG}'"
+        )
+
+
+class TestMkdocsUrls:
+    """mkdocs.yml — site_url, repo_name, and repo_url must use current names."""
+
+    def test_site_url_is_current(self):
+        content = MKDOCS.read_text()
+        assert f"site_url: {CORRECT_SITE_URL}" in content, (
+            f"mkdocs.yml site_url must be '{CORRECT_SITE_URL}'"
+        )
+
+    def test_repo_name_is_current(self):
+        content = MKDOCS.read_text()
+        assert f"repo_name: {CORRECT_REPO_SLUG}" in content, (
+            f"mkdocs.yml repo_name must be '{CORRECT_REPO_SLUG}'"
+        )
+
+    def test_repo_url_is_current(self):
+        content = MKDOCS.read_text()
+        assert f"repo_url: {CORRECT_REPO_URL}" in content, (
+            f"mkdocs.yml repo_url must be '{CORRECT_REPO_URL}'"
+        )
+
+    def test_stale_site_url_absent(self):
+        content = MKDOCS.read_text()
+        assert STALE_SITE_URL not in content, (
+            f"mkdocs.yml must not contain stale site_url '{STALE_SITE_URL}'"
+        )
+
+    def test_stale_repo_name_absent(self):
+        content = MKDOCS.read_text()
+        assert STALE_REPO_NAME not in content, (
+            f"mkdocs.yml must not contain stale repo_name '{STALE_REPO_NAME}'"
+        )
+
+    def test_stale_repo_url_absent(self):
+        content = MKDOCS.read_text()
+        assert STALE_REPO_URL not in content, (
+            f"mkdocs.yml must not contain stale repo_url '{STALE_REPO_URL}'"
+        )


### PR DESCRIPTION
## Summary
Resolves #227 — FEATURE: Fix stale CI badge URL in README.md and correct mismatched site_url and repo_url in mkdocs.yml
## Changes
- ### Issue 1
- ### Issue 2

**Tasks:**
- In `README.md` line 3, replace the badge image URL from
- In `README.md` line 3, replace the badge anchor href from
- In `mkdocs.yml` line 5, update `site_url` from
- In `mkdocs.yml` line 6, update `repo_name` from
- In `mkdocs.yml` line 7, update `repo_url` from
- All existing and new tests pass locally (pytest / mvn test / npm test / etc.)
- All existing and new lint checks pass locally (ruff / eslint / ng lint / etc.)
## Testing
Run the full test suite — all tests must pass.
Closes #227