### PR TITLE
fix: resolve #234 - FEATURE: Create an abbreviation section in each topic for al

### DIFF
--- a/docs/aws/files/abbreviations/abbreviations.md
+++ b/docs/aws/files/abbreviations/abbreviations.md
@@ -1,0 +1,68 @@
+# ABBREVIATIONS
+
+Centralised reference for every capitalised abbreviation used across the AWS
+cheat-sheet sections (compute, networking, storage, identity, security,
+database, monitoring, messaging, governance, ha-dr, waf).
+
+| Abbreviation | Definition |
+| --- | --- |
+| ACL | Access Control List — rules controlling inbound and outbound traffic; used in VPC Network ACLs |
+| ACM | AWS Certificate Manager — managed TLS/SSL certificate provisioning and renewal service |
+| ALB | Application Load Balancer — L7 HTTP/HTTPS load balancer with content-based routing |
+| AMI | Amazon Machine Image — pre-configured virtual machine template used to launch EC2 instances |
+| ARN | Amazon Resource Name — unique identifier string for every AWS resource |
+| AZ | Availability Zone — physically isolated datacenter within an AWS Region |
+| CDN | Content Delivery Network — globally distributed edge cache; delivered by Amazon CloudFront |
+| CIDR | Classless Inter-Domain Routing — IP address range notation used in VPC and subnet definitions |
+| CMK | Customer-Managed Key — KMS key created and managed by the customer |
+| CPU | Central Processing Unit — primary compute processor |
+| CRR | Cross-Region Replication — automatic S3 object replication to a bucket in another region |
+| DAX | DynamoDB Accelerator — in-memory cache for DynamoDB reducing read latency to microseconds |
+| DLQ | Dead-Letter Queue — SQS or SNS queue for undeliverable messages after maximum receive attempts |
+| DNS | Domain Name System — resolves hostnames to IP addresses; delivered by Amazon Route 53 |
+| DR | Disaster Recovery — strategies for restoring workloads after a catastrophic failure |
+| DRT | DDoS Response Team — AWS Shield Advanced team providing 24/7 attack support |
+| EBS | Elastic Block Store — persistent block storage volumes attached to EC2 instances |
+| EC2 | Elastic Compute Cloud — scalable virtual machine service |
+| ECS | Elastic Container Service — fully managed container orchestration service |
+| EFS | Elastic File System — fully managed, elastic NFS file system for Linux workloads |
+| EKS | Elastic Kubernetes Service — managed Kubernetes cluster service |
+| ETL | Extract, Transform, Load — pipeline pattern for moving data; delivered by AWS Glue |
+| FIFO | First In, First Out — message ordering and deduplication guarantee for SQS FIFO queues |
+| GPU | Graphics Processing Unit — parallel compute accelerator used in EC2 P and G instance families |
+| HA | High Availability — design pattern eliminating single points of failure for continuous operation |
+| IA | Infrequent Access — S3 and EFS storage class optimised for data accessed less than once per month |
+| IAM | Identity and Access Management — AWS service for managing users, roles, and permissions |
+| KMS | Key Management Service — managed service for creating and controlling encryption keys |
+| MFA | Multi-Factor Authentication — authentication requiring two or more verification factors |
+| ML | Machine Learning — AI workloads; Amazon SageMaker is the managed training and inference platform |
+| MTBF | Mean Time Between Failures — average time between system failures; reliability metric |
+| MTTR | Mean Time To Recovery — average time to restore service after a failure |
+| NAT | Network Address Translation — maps private IP addresses to a public IP for outbound internet traffic |
+| NFS | Network File System — file-sharing protocol used by Amazon EFS |
+| NLB | Network Load Balancer — L4 TCP/UDP load balancer for ultra-high throughput and static IP support |
+| OIDC | OpenID Connect — identity federation protocol used with IAM Identity Center and IRSA on EKS |
+| OLAP | Online Analytical Processing — analytical query workload; served by Amazon Redshift |
+| OU | Organizational Unit — container within AWS Organizations for grouping accounts and applying SCPs |
+| PII | Personally Identifiable Information — sensitive data subject to privacy regulations |
+| RDS | Relational Database Service — managed relational database engine hosting MySQL, PostgreSQL, SQL Server and others |
+| RPO | Recovery Point Objective — maximum acceptable data loss window measured in time |
+| RTO | Recovery Time Objective — maximum acceptable downtime window after a failure |
+| S3 | Simple Storage Service — scalable, durable object storage service |
+| SAML | Security Assertion Markup Language — XML-based federation protocol used in IAM Identity Center SSO |
+| SCP | Service Control Policy — organization-wide permission guardrails applied via AWS Organizations |
+| SIEM | Security Information and Event Management — log aggregation and threat detection platform |
+| SLA | Service Level Agreement — AWS's uptime and availability commitments per service |
+| SNS | Simple Notification Service — managed pub/sub messaging and mobile push service |
+| SQL | Structured Query Language — query language used by relational databases including Amazon RDS and Redshift |
+| SQS | Simple Queue Service — managed message queue for decoupling distributed application components |
+| SSE | Server-Side Encryption — storage service encrypts data at rest before writing |
+| SSO | Single Sign-On — authentication allowing one login to access multiple services; delivered via IAM Identity Center |
+| STS | Security Token Service — issues temporary, scoped credentials for IAM role assumption |
+| TCP | Transmission Control Protocol — connection-oriented L4 transport protocol |
+| TLS | Transport Layer Security — cryptographic protocol enforcing encryption in transit |
+| TPS | Transactions Per Second — throughput capacity metric for databases and messaging services |
+| UDP | User Datagram Protocol — connectionless L4 transport protocol for low-latency workloads |
+| VPC | Virtual Private Cloud — logically isolated virtual network in AWS |
+| VPN | Virtual Private Network — encrypted tunnel connecting on-premises networks to a VPC |
+| WAF | Web Application Firewall — L7 filter protecting web apps from OWASP Top 10 attacks; delivered by AWS WAF |

--- a/docs/aws/files/exams/exams.md
+++ b/docs/aws/files/exams/exams.md
@@ -2,6 +2,7 @@
 
 | Section | CLF-C02 | SAA-C03 | SAP-C02 |
 | --- | --- | --- | --- |
+| [Abbreviations](../abbreviations/abbreviations.md) | — | — | — |
 | [Compute](../compute/compute.md) | Partial | Full | Full |
 | [Networking](../networking/networking.md) | Partial | Full | Full |
 | [Storage](../storage/storage.md) | Partial | Full | Full |

--- a/docs/azure/files/abbreviations/abbreviations.md
+++ b/docs/azure/files/abbreviations/abbreviations.md
@@ -1,0 +1,121 @@
+# ABBREVIATIONS
+
+Centralised reference for every capitalised abbreviation used across the Azure
+cheat-sheet sections (networking, security, storage, monitoring, compute,
+identity, ha-dr, governance, messaging, waf).
+
+| Abbreviation | Definition |
+| --- | --- |
+| AAD | Azure Active Directory — legacy name for Microsoft Entra ID |
+| ACA | Azure Container Apps — serverless container hosting service |
+| ACI | Azure Container Instances — on-demand single-container hosting without orchestration |
+| ACL | Access Control List — rules that grant or deny traffic at the network or storage layer |
+| ACR | Azure Container Registry — private Docker/OCI image registry |
+| ADF | Azure Data Factory — managed ETL and data integration service |
+| ADLS | Azure Data Lake Storage — hierarchical namespace storage built on Blob |
+| AKS | Azure Kubernetes Service — managed Kubernetes cluster service |
+| AMA | Azure Monitor Agent — unified agent replacing MMA and WAD for telemetry collection |
+| APIM | Azure API Management — managed API gateway with policies and developer portal |
+| APM | Application Performance Monitoring — observability of application response times and errors |
+| ARM | Azure Resource Manager — deployment and management layer for all Azure resources |
+| ASE | App Service Environment — isolated, dedicated App Service plan in a VNet |
+| ASG | Application Security Group — groups VMs for NSG rule simplification |
+| ASR | Azure Site Recovery — disaster recovery replication and failover service |
+| AZ | Availability Zone — physically separate datacenter within an Azure region |
+| BGP | Border Gateway Protocol — dynamic routing protocol used in ExpressRoute and VPN Gateway |
+| BYOD | Bring Your Own Device — policy allowing personal devices to access corporate resources |
+| CA | Certificate Authority — trusted entity that issues TLS/SSL certificates |
+| CDN | Content Delivery Network — globally distributed edge cache for static and dynamic content |
+| CIAM | Customer Identity and Access Management — identity platform for external/consumer users |
+| CIDR | Classless Inter-Domain Routing — IP address range notation used in VNet and subnet definitions |
+| CMK | Customer-Managed Key — encryption key stored in Key Vault and controlled by the customer |
+| CNCF | Cloud Native Computing Foundation — standards body for Kubernetes and cloud-native projects |
+| CNI | Container Network Interface — plugin specification for container networking (used in AKS) |
+| CPU | Central Processing Unit — primary compute processor |
+| CSPM | Cloud Security Posture Management — continuous assessment of cloud resource configurations |
+| DCR | Data Collection Rule — configuration object that controls log and metric routing in Azure Monitor |
+| DLQ | Dead-Letter Queue — holding queue for undeliverable messages in Service Bus and Event Hubs |
+| DNS | Domain Name System — resolves hostnames to IP addresses; Azure provides Azure DNS and Private DNS |
+| DR | Disaster Recovery — strategies and services to restore operations after a catastrophic failure |
+| DTU | Database Transaction Unit — blended compute, memory, and I/O capacity unit for Azure SQL Basic/Standard/Premium tiers |
+| ETL | Extract, Transform, Load — pipeline pattern for moving data between systems |
+| FIFO | First In, First Out — message ordering guarantee supported by Service Bus queues |
+| FPGA | Field-Programmable Gate Array — reconfigurable hardware accelerator available in some Azure VM SKUs |
+| FQDN | Fully Qualified Domain Name — complete domain name including all labels (e.g. app.contoso.com) |
+| GPO | Group Policy Object — Active Directory policy container applied to users and computers |
+| GPU | Graphics Processing Unit — parallel compute accelerator used for AI, ML, and HPC workloads |
+| GRS | Geo-Redundant Storage — replication to a secondary Azure region for disaster recovery |
+| GZRS | Geo-Zone-Redundant Storage — replication across availability zones in the primary region and to a secondary region |
+| HA | High Availability — design pattern that eliminates single points of failure for continuous operation |
+| HDD | Hard Disk Drive — magnetic spinning disk; used for low-cost, infrequently accessed storage |
+| HPA | Horizontal Pod Autoscaler — Kubernetes controller that scales pod replicas based on metrics |
+| HPC | High Performance Computing — workloads requiring large-scale parallel processing |
+| HSM | Hardware Security Module — dedicated cryptographic device for key generation and storage |
+| IDPS | Intrusion Detection and Prevention System — monitors and blocks malicious network traffic |
+| IKE | Internet Key Exchange — protocol used to establish IPSec VPN tunnels |
+| IOPS | Input/Output Operations Per Second — storage throughput performance metric |
+| JIT | Just-In-Time — access model that grants elevated permissions only when explicitly requested |
+| JWT | JSON Web Token — compact, signed token format used in OAuth 2.0 and OIDC flows |
+| KEDA | Kubernetes Event-Driven Autoscaling — open-source scaler for event-source-driven pod scaling |
+| KQL | Kusto Query Language — query language used in Azure Monitor Logs and Microsoft Sentinel |
+| LDAP | Lightweight Directory Access Protocol — protocol for querying and modifying directory services |
+| LRS | Locally Redundant Storage — three synchronous copies within a single datacenter |
+| MDE | Microsoft Defender for Endpoint — EDR solution integrated with Defender for Servers |
+| MDM | Mobile Device Management — platform for managing and enforcing policy on devices |
+| MFA | Multi-Factor Authentication — authentication requiring two or more verification factors |
+| MI | Managed Identity — Azure-managed service principal that eliminates the need for credentials in code |
+| ML | Machine Learning — AI workloads; Azure ML is the managed training and inference platform |
+| MMA | Microsoft Monitoring Agent — legacy Log Analytics agent replaced by AMA |
+| MPI | Message Passing Interface — parallel computing communication standard used in HPC clusters |
+| MSAL | Microsoft Authentication Library — SDK for acquiring tokens from the Microsoft identity platform |
+| MSP | Managed Service Provider — third-party company that manages Azure resources on behalf of customers |
+| NAT | Network Address Translation — maps private IP addresses to a public IP for outbound internet access |
+| NIC | Network Interface Card — virtual network adapter attached to a VM |
+| NIST | National Institute of Standards and Technology — US standards body; NIST frameworks used in Azure Policy |
+| NSG | Network Security Group — stateful L4 packet filter applied to subnets or NICs |
+| NTLM | NT LAN Manager — legacy Windows challenge-response authentication protocol |
+| NVA | Network Virtual Appliance — third-party firewall or router VM deployed in a VNet |
+| OBO | On-Behalf-Of — OAuth 2.0 flow where a middle-tier API exchanges a token on behalf of a user |
+| OIDC | OpenID Connect — identity layer on top of OAuth 2.0 for authentication |
+| OLAP | Online Analytical Processing — query workload optimised for aggregation and reporting |
+| OLTP | Online Transaction Processing — query workload optimised for high-frequency read/write operations |
+| OMS | Operations Management Suite — legacy name for the suite now known as Azure Monitor and Log Analytics |
+| PITR | Point-In-Time Restore — database recovery to a specific timestamp |
+| PKCE | Proof Key for Code Exchange — OAuth 2.0 extension that prevents authorization code interception in public clients |
+| PMK | Platform-Managed Key — encryption key generated and managed entirely by Microsoft |
+| POSIX | Portable Operating System Interface — standard for file system semantics; required by ADLS Gen2 |
+| RA | Read Access — prefix indicating read-access geo-redundancy (e.g. RA-GRS, RA-GZRS) |
+| RBAC | Role-Based Access Control — authorization model granting permissions via role assignments |
+| RDMA | Remote Direct Memory Access — low-latency network communication bypassing the CPU, used in HPC VMs |
+| RDP | Remote Desktop Protocol — protocol for remote graphical desktop access to Windows VMs |
+| RPO | Recovery Point Objective — maximum acceptable data loss window measured in time |
+| RSA | Rivest–Shamir–Adleman — asymmetric encryption algorithm used in Key Vault RSA keys |
+| RTO | Recovery Time Objective — maximum acceptable downtime window after a failure |
+| RU | Request Unit — capacity unit in Azure Cosmos DB representing the cost of a database operation |
+| SAML | Security Assertion Markup Language — XML-based federation protocol for SSO |
+| SAS | Shared Access Signature — time-limited, scoped URL granting delegated access to Azure Storage |
+| SIEM | Security Information and Event Management — platform for log aggregation, correlation, and alerting |
+| SKU | Stock Keeping Unit — product tier or size identifier for Azure services |
+| SLA | Service Level Agreement — Microsoft's uptime and connectivity commitments per service |
+| SMB | Server Message Block — file-sharing protocol used by Azure Files |
+| SNAT | Source Network Address Translation — translates outbound private IP to a public IP |
+| SOAR | Security Orchestration, Automation, and Response — automated incident response via playbooks |
+| SPA | Single-Page Application — browser-based app using OAuth 2.0 Authorization Code + PKCE flow |
+| SQL | Structured Query Language — query language used by relational databases |
+| SSD | Solid-State Drive — flash storage; used for high-performance managed disks |
+| SSE | Server-Side Encryption — storage service encrypts data before writing to disk |
+| SSH | Secure Shell — encrypted protocol for remote command-line access to Linux VMs |
+| SSO | Single Sign-On — authentication mechanism allowing one login to access multiple services |
+| SSPR | Self-Service Password Reset — Entra ID feature allowing users to reset their own passwords |
+| TLS | Transport Layer Security — cryptographic protocol enforcing encryption in transit |
+| TTL | Time to Live — duration a DNS record or cache entry is valid |
+| UDR | User-Defined Route — custom route table entry that overrides Azure default routing |
+| UEBA | User and Entity Behavior Analytics — Sentinel feature detecting anomalous user/resource behaviour |
+| URI | Uniform Resource Identifier — string identifying a resource; used in Key Vault references and OAuth scopes |
+| VMSS | Virtual Machine Scale Set — automatically scales a group of identical VMs |
+| VNet | Virtual Network — isolated, software-defined network in Azure |
+| VPN | Virtual Private Network — encrypted tunnel connecting on-premises or remote networks to Azure |
+| WAD | Windows Azure Diagnostics — legacy diagnostics agent replaced by AMA |
+| WAF | Web Application Firewall — L7 filter protecting web apps from OWASP Top 10 attacks |
+| WAN | Wide Area Network — large-scale network; Azure Virtual WAN is the managed hub-and-spoke topology |
+| ZRS | Zone-Redundant Storage — three synchronous copies across three availability zones in one region |

--- a/docs/azure/files/exams/exams.md
+++ b/docs/azure/files/exams/exams.md
@@ -2,6 +2,7 @@
 
 | Section | AZ-900 | AZ-104 | AZ-204 | AZ-305 | AZ-500 | AZ-700 |
 | --- | --- | --- | --- | --- | --- | --- |
+| [Abbreviations](../abbreviations/abbreviations.md) | — | — | — | — | — | — |
 | [Networking](../networking/networking.md) | Partial | Full | — | Full | Partial | Full |
 | [Security](../security/security.md) | — | Partial | Partial | Full | Full | — |
 | [Storage](../storage/storage.md) | Partial | Full | Partial | Full | — | — |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Azure:
+      - Abbreviations: azure/files/abbreviations/abbreviations.md
       - Exam Coverage: azure/files/exams/exams.md
       - Networking: azure/files/networking/networking.md
       - Security: azure/files/security/security.md
@@ -70,6 +71,7 @@ nav:
       - Messaging & Integration: azure/files/messaging/messaging.md
       - Well-Architected Framework: azure/files/waf/waf.md
   - AWS:
+      - Abbreviations: aws/files/abbreviations/abbreviations.md
       - Exam Coverage: aws/files/exams/exams.md
       - Compute: aws/files/compute/compute.md
       - Networking: aws/files/networking/networking.md

--- a/tests/test_issue_232.py
+++ b/tests/test_issue_232.py
@@ -170,9 +170,7 @@ class TestMkdocsAWSExamCoverage:
 
     def test_aws_exam_coverage_is_first_under_aws(self, mkdocs_text):
         lines = mkdocs_text.splitlines()
-        aws_idx = next(
-            (i for i, line in enumerate(lines) if line.strip() == "- AWS:"), None
-        )
+        aws_idx = next((i for i, line in enumerate(lines) if line.strip() == "- AWS:"), None)
         assert aws_idx is not None, "- AWS: section not found in mkdocs.yml"
         # Find next nav entries after - AWS:
         child_entries = []
@@ -204,9 +202,7 @@ class TestAzureExamsUnchanged:
         assert "AZ-204" in azure_exams_text
 
     def test_azure_exams_has_seven_columns(self, azure_exams_text):
-        header = next(
-            (line for line in azure_exams_text.splitlines() if "Section" in line), None
-        )
+        header = next((line for line in azure_exams_text.splitlines() if "Section" in line), None)
         assert header is not None
         # 7 columns: Section, AZ-900, AZ-104, AZ-204, AZ-305, AZ-500, AZ-700
         assert header.count("|") >= 8  # at least 7 columns = 8 pipes

--- a/tests/test_issue_232.py
+++ b/tests/test_issue_232.py
@@ -150,13 +150,13 @@ class TestAWSExamsFileContent:
         assert "Well-Architected" in aws_exams_text
 
     def test_eleven_data_rows(self, aws_exams_text):
-        # 11 domain rows expected (header + separator + 11 data rows)
+        # 11 domain rows + 1 abbreviations row = 12 total data rows (issue #234)
         data_rows = [
             line
             for line in aws_exams_text.splitlines()
             if line.strip().startswith("|") and "---" not in line and "Section" not in line
         ]
-        assert len(data_rows) == 11, f"Expected 11 data rows, got {len(data_rows)}"
+        assert len(data_rows) == 12, f"Expected 12 data rows, got {len(data_rows)}"
 
 
 # ── TASK 4: mkdocs.yml — AWS Exam Coverage registered ────────────────────────
@@ -187,8 +187,10 @@ class TestMkdocsAWSExamCoverage:
                 child_entries.append(stripped)
                 break
         assert child_entries, "No child entries found under - AWS:"
-        assert "Exam Coverage" in child_entries[0], (
-            f"First AWS child is not Exam Coverage, got: {child_entries[0]}"
+        # Abbreviations is now the first entry under AWS (issue #234);
+        # Exam Coverage is the second entry.
+        assert "Abbreviations" in child_entries[0], (
+            f"First AWS child is not Abbreviations, got: {child_entries[0]}"
         )
 
 
@@ -215,4 +217,5 @@ class TestAzureExamsUnchanged:
             for line in azure_exams_text.splitlines()
             if line.strip().startswith("|") and "---" not in line and "Section" not in line
         ]
-        assert len(data_rows) == 10, f"Expected 10 data rows, got {len(data_rows)}"
+        # 10 domain rows + 1 abbreviations row = 11 total data rows (issue #234)
+        assert len(data_rows) == 11, f"Expected 11 data rows, got {len(data_rows)}"

--- a/tests/test_issue_233.py
+++ b/tests/test_issue_233.py
@@ -164,7 +164,7 @@ class TestExistingContentPreserved:
         assert 'The "s" suffix (e.g., Dsv5) indicates Premium SSD support' in compute_text
 
     def test_vm_family_decision_flow_diagram_present(self, compute_text):
-        assert '### VM Family Decision Flow' in compute_text
+        assert "### VM Family Decision Flow" in compute_text
 
     def test_vm_family_decision_flow_mmd_snippet(self, compute_text):
         assert '--8<-- "azure/diagrams/compute/vm-family-decision-flow.mmd"' in compute_text

--- a/tests/test_issue_234.py
+++ b/tests/test_issue_234.py
@@ -81,7 +81,18 @@ def aws_abbrev_text():
 
 @pytest.fixture(scope="module")
 def mkdocs_config():
-    return yaml.safe_load(MKDOCS_YML.read_text())
+    # mkdocs.yml uses !!python/name: tags that yaml.safe_load cannot handle.
+    # Register a constructor that treats unknown python/* tags as plain strings.
+    loader_class = yaml.SafeLoader
+
+    def _python_name_constructor(loader, tag_suffix, node):
+        return loader.construct_scalar(node)
+
+    loader_class.add_multi_constructor(
+        "tag:yaml.org,2002:python/name:",
+        _python_name_constructor,
+    )
+    return yaml.load(MKDOCS_YML.read_text(), Loader=loader_class)
 
 
 @pytest.fixture(scope="module")
@@ -248,7 +259,7 @@ class TestMkdocsNavAzure:
             None,
         )
         assert azure_section is not None, "Azure nav section not found in mkdocs.yml"
-        entry_keys = [list(e.keys())[0] for e in azure_section]
+        entry_keys = [next(iter(e.keys())) for e in azure_section]
         assert "Abbreviations" in entry_keys, (
             "Abbreviations entry not found in Azure nav block"
         )
@@ -272,7 +283,7 @@ class TestMkdocsNavAzure:
             (item["Azure"] for item in mkdocs_config["nav"] if "Azure" in item),
             None,
         )
-        entry_keys = [list(e.keys())[0] for e in azure_section]
+        entry_keys = [next(iter(e.keys())) for e in azure_section]
         abbrev_idx = entry_keys.index("Abbreviations")
         exam_idx = entry_keys.index("Exam Coverage")
         assert abbrev_idx < exam_idx, (
@@ -290,7 +301,7 @@ class TestMkdocsNavAws:
             None,
         )
         assert aws_section is not None, "AWS nav section not found in mkdocs.yml"
-        entry_keys = [list(e.keys())[0] for e in aws_section]
+        entry_keys = [next(iter(e.keys())) for e in aws_section]
         assert "Abbreviations" in entry_keys, (
             "Abbreviations entry not found in AWS nav block"
         )
@@ -314,7 +325,7 @@ class TestMkdocsNavAws:
             (item["AWS"] for item in mkdocs_config["nav"] if "AWS" in item),
             None,
         )
-        entry_keys = [list(e.keys())[0] for e in aws_section]
+        entry_keys = [next(iter(e.keys())) for e in aws_section]
         abbrev_idx = entry_keys.index("Abbreviations")
         exam_idx = entry_keys.index("Exam Coverage")
         assert abbrev_idx < exam_idx, (

--- a/tests/test_issue_234.py
+++ b/tests/test_issue_234.py
@@ -138,13 +138,9 @@ class TestAzureAbbreviationsTableStructure:
         data_rows = [
             ln
             for ln in lines
-            if ln.strip().startswith("|")
-            and "---" not in ln
-            and "Abbreviation" not in ln
+            if ln.strip().startswith("|") and "---" not in ln and "Abbreviation" not in ln
         ]
-        assert len(data_rows) >= 10, (
-            f"Expected at least 10 abbreviation rows, got {len(data_rows)}"
-        )
+        assert len(data_rows) >= 10, f"Expected at least 10 abbreviation rows, got {len(data_rows)}"
 
 
 class TestAzureAbbreviationsAlphaOrder:
@@ -154,16 +150,10 @@ class TestAzureAbbreviationsAlphaOrder:
         lines = azure_abbrev_text.splitlines()
         abbrevs = []
         for ln in lines:
-            if (
-                ln.strip().startswith("|")
-                and "---" not in ln
-                and "Abbreviation" not in ln
-            ):
+            if ln.strip().startswith("|") and "---" not in ln and "Abbreviation" not in ln:
                 first_col = ln.split("|")[1].strip()
                 abbrevs.append(first_col)
-        assert abbrevs == sorted(abbrevs), (
-            f"Abbreviations are not sorted: {abbrevs}"
-        )
+        assert abbrevs == sorted(abbrevs), f"Abbreviations are not sorted: {abbrevs}"
 
 
 class TestAzureRequiredAbbreviations:
@@ -209,13 +199,9 @@ class TestAwsAbbreviationsTableStructure:
         data_rows = [
             ln
             for ln in lines
-            if ln.strip().startswith("|")
-            and "---" not in ln
-            and "Abbreviation" not in ln
+            if ln.strip().startswith("|") and "---" not in ln and "Abbreviation" not in ln
         ]
-        assert len(data_rows) >= 10, (
-            f"Expected at least 10 abbreviation rows, got {len(data_rows)}"
-        )
+        assert len(data_rows) >= 10, f"Expected at least 10 abbreviation rows, got {len(data_rows)}"
 
 
 class TestAwsAbbreviationsAlphaOrder:
@@ -225,16 +211,10 @@ class TestAwsAbbreviationsAlphaOrder:
         lines = aws_abbrev_text.splitlines()
         abbrevs = []
         for ln in lines:
-            if (
-                ln.strip().startswith("|")
-                and "---" not in ln
-                and "Abbreviation" not in ln
-            ):
+            if ln.strip().startswith("|") and "---" not in ln and "Abbreviation" not in ln:
                 first_col = ln.split("|")[1].strip()
                 abbrevs.append(first_col)
-        assert abbrevs == sorted(abbrevs), (
-            f"Abbreviations are not sorted: {abbrevs}"
-        )
+        assert abbrevs == sorted(abbrevs), f"Abbreviations are not sorted: {abbrevs}"
 
 
 class TestAwsRequiredAbbreviations:
@@ -260,9 +240,7 @@ class TestMkdocsNavAzure:
         )
         assert azure_section is not None, "Azure nav section not found in mkdocs.yml"
         entry_keys = [next(iter(e.keys())) for e in azure_section]
-        assert "Abbreviations" in entry_keys, (
-            "Abbreviations entry not found in Azure nav block"
-        )
+        assert "Abbreviations" in entry_keys, "Abbreviations entry not found in Azure nav block"
 
     def test_azure_abbreviations_points_to_correct_file(self, mkdocs_config):
         azure_section = next(
@@ -302,9 +280,7 @@ class TestMkdocsNavAws:
         )
         assert aws_section is not None, "AWS nav section not found in mkdocs.yml"
         entry_keys = [next(iter(e.keys())) for e in aws_section]
-        assert "Abbreviations" in entry_keys, (
-            "Abbreviations entry not found in AWS nav block"
-        )
+        assert "Abbreviations" in entry_keys, "Abbreviations entry not found in AWS nav block"
 
     def test_aws_abbreviations_points_to_correct_file(self, mkdocs_config):
         aws_section = next(

--- a/tests/test_issue_234.py
+++ b/tests/test_issue_234.py
@@ -1,0 +1,385 @@
+"""Tests for issue #234 - FEATURE: Create an abbreviation section in each topic.
+
+Verifies that:
+  - docs/azure/files/abbreviations/abbreviations.md exists with # ABBREVIATIONS heading
+  - docs/azure/files/abbreviations/abbreviations.md contains a table with
+    Abbreviation and Definition columns
+  - docs/aws/files/abbreviations/abbreviations.md exists with # ABBREVIATIONS heading
+  - docs/aws/files/abbreviations/abbreviations.md contains a table with
+    Abbreviation and Definition columns
+  - mkdocs.yml has Abbreviations nav entry as first child under Azure (before Exam Coverage)
+  - mkdocs.yml has Abbreviations nav entry as first child under AWS (before Exam Coverage)
+  - docs/azure/files/exams/exams.md has Abbreviations as first data row in the table
+  - docs/aws/files/exams/exams.md has Abbreviations as first data row in the table
+"""
+
+import pathlib
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+AZURE_ABBREV_MD = REPO_ROOT / "docs" / "azure" / "files" / "abbreviations" / "abbreviations.md"
+AWS_ABBREV_MD = REPO_ROOT / "docs" / "aws" / "files" / "abbreviations" / "abbreviations.md"
+MKDOCS_YML = REPO_ROOT / "mkdocs.yml"
+AZURE_EXAMS_MD = REPO_ROOT / "docs" / "azure" / "files" / "exams" / "exams.md"
+AWS_EXAMS_MD = REPO_ROOT / "docs" / "aws" / "files" / "exams" / "exams.md"
+
+# Key abbreviations that must appear in the Azure abbreviations table
+AZURE_REQUIRED_ABBREVIATIONS = [
+    "AAD",
+    "ACR",
+    "AKS",
+    "APIM",
+    "ARM",
+    "CDN",
+    "DNS",
+    "GRS",
+    "NSG",
+    "RBAC",
+    "SLA",
+    "SQL",
+    "UDR",
+    "VNet",
+    "VPN",
+    "WAF",
+]
+
+# Key abbreviations that must appear in the AWS abbreviations table
+AWS_REQUIRED_ABBREVIATIONS = [
+    "ACL",
+    "AMI",
+    "ARN",
+    "AZ",
+    "CDN",
+    "DNS",
+    "EC2",
+    "IAM",
+    "KMS",
+    "RDS",
+    "S3",
+    "SNS",
+    "SQS",
+    "VPC",
+    "WAF",
+]
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def azure_abbrev_text():
+    return AZURE_ABBREV_MD.read_text()
+
+
+@pytest.fixture(scope="module")
+def aws_abbrev_text():
+    return AWS_ABBREV_MD.read_text()
+
+
+@pytest.fixture(scope="module")
+def mkdocs_config():
+    return yaml.safe_load(MKDOCS_YML.read_text())
+
+
+@pytest.fixture(scope="module")
+def azure_exams_text():
+    return AZURE_EXAMS_MD.read_text()
+
+
+@pytest.fixture(scope="module")
+def aws_exams_text():
+    return AWS_EXAMS_MD.read_text()
+
+
+# ── Issue 1: Azure abbreviations file ────────────────────────────────────────
+
+
+class TestAzureAbbreviationsFileExists:
+    """docs/azure/files/abbreviations/abbreviations.md must exist."""
+
+    def test_file_exists(self):
+        assert AZURE_ABBREV_MD.exists(), (
+            f"{AZURE_ABBREV_MD} does not exist — create it with # ABBREVIATIONS heading"
+        )
+
+
+class TestAzureAbbreviationsHeading:
+    """The Azure abbreviations file must start with # ABBREVIATIONS."""
+
+    def test_heading_present(self, azure_abbrev_text):
+        assert "# ABBREVIATIONS" in azure_abbrev_text
+
+
+class TestAzureAbbreviationsTableStructure:
+    """The Azure abbreviations file must contain a two-column Markdown table."""
+
+    def test_table_header_present(self, azure_abbrev_text):
+        assert "| Abbreviation | Definition |" in azure_abbrev_text
+
+    def test_table_separator_present(self, azure_abbrev_text):
+        assert "| --- | --- |" in azure_abbrev_text
+
+    def test_table_has_data_rows(self, azure_abbrev_text):
+        lines = azure_abbrev_text.splitlines()
+        data_rows = [
+            ln
+            for ln in lines
+            if ln.strip().startswith("|")
+            and "---" not in ln
+            and "Abbreviation" not in ln
+        ]
+        assert len(data_rows) >= 10, (
+            f"Expected at least 10 abbreviation rows, got {len(data_rows)}"
+        )
+
+
+class TestAzureAbbreviationsAlphaOrder:
+    """Abbreviations must appear in alphabetical order (first column)."""
+
+    def test_alphabetically_sorted(self, azure_abbrev_text):
+        lines = azure_abbrev_text.splitlines()
+        abbrevs = []
+        for ln in lines:
+            if (
+                ln.strip().startswith("|")
+                and "---" not in ln
+                and "Abbreviation" not in ln
+            ):
+                first_col = ln.split("|")[1].strip()
+                abbrevs.append(first_col)
+        assert abbrevs == sorted(abbrevs), (
+            f"Abbreviations are not sorted: {abbrevs}"
+        )
+
+
+class TestAzureRequiredAbbreviations:
+    """Key Azure abbreviations must be present in the table."""
+
+    @pytest.mark.parametrize("abbrev", AZURE_REQUIRED_ABBREVIATIONS)
+    def test_abbreviation_present(self, azure_abbrev_text, abbrev):
+        assert abbrev in azure_abbrev_text, (
+            f"Expected abbreviation '{abbrev}' not found in azure abbreviations.md"
+        )
+
+
+# ── Issue 2: AWS abbreviations file ──────────────────────────────────────────
+
+
+class TestAwsAbbreviationsFileExists:
+    """docs/aws/files/abbreviations/abbreviations.md must exist."""
+
+    def test_file_exists(self):
+        assert AWS_ABBREV_MD.exists(), (
+            f"{AWS_ABBREV_MD} does not exist — create it with # ABBREVIATIONS heading"
+        )
+
+
+class TestAwsAbbreviationsHeading:
+    """The AWS abbreviations file must start with # ABBREVIATIONS."""
+
+    def test_heading_present(self, aws_abbrev_text):
+        assert "# ABBREVIATIONS" in aws_abbrev_text
+
+
+class TestAwsAbbreviationsTableStructure:
+    """The AWS abbreviations file must contain a two-column Markdown table."""
+
+    def test_table_header_present(self, aws_abbrev_text):
+        assert "| Abbreviation | Definition |" in aws_abbrev_text
+
+    def test_table_separator_present(self, aws_abbrev_text):
+        assert "| --- | --- |" in aws_abbrev_text
+
+    def test_table_has_data_rows(self, aws_abbrev_text):
+        lines = aws_abbrev_text.splitlines()
+        data_rows = [
+            ln
+            for ln in lines
+            if ln.strip().startswith("|")
+            and "---" not in ln
+            and "Abbreviation" not in ln
+        ]
+        assert len(data_rows) >= 10, (
+            f"Expected at least 10 abbreviation rows, got {len(data_rows)}"
+        )
+
+
+class TestAwsAbbreviationsAlphaOrder:
+    """Abbreviations must appear in alphabetical order (first column)."""
+
+    def test_alphabetically_sorted(self, aws_abbrev_text):
+        lines = aws_abbrev_text.splitlines()
+        abbrevs = []
+        for ln in lines:
+            if (
+                ln.strip().startswith("|")
+                and "---" not in ln
+                and "Abbreviation" not in ln
+            ):
+                first_col = ln.split("|")[1].strip()
+                abbrevs.append(first_col)
+        assert abbrevs == sorted(abbrevs), (
+            f"Abbreviations are not sorted: {abbrevs}"
+        )
+
+
+class TestAwsRequiredAbbreviations:
+    """Key AWS abbreviations must be present in the table."""
+
+    @pytest.mark.parametrize("abbrev", AWS_REQUIRED_ABBREVIATIONS)
+    def test_abbreviation_present(self, aws_abbrev_text, abbrev):
+        assert abbrev in aws_abbrev_text, (
+            f"Expected abbreviation '{abbrev}' not found in aws abbreviations.md"
+        )
+
+
+# ── Issue 3: mkdocs.yml nav ───────────────────────────────────────────────────
+
+
+class TestMkdocsNavAzure:
+    """mkdocs.yml must have Abbreviations as first child under Azure."""
+
+    def test_azure_abbreviations_nav_entry_present(self, mkdocs_config):
+        azure_section = next(
+            (item["Azure"] for item in mkdocs_config["nav"] if "Azure" in item),
+            None,
+        )
+        assert azure_section is not None, "Azure nav section not found in mkdocs.yml"
+        entry_keys = [list(e.keys())[0] for e in azure_section]
+        assert "Abbreviations" in entry_keys, (
+            "Abbreviations entry not found in Azure nav block"
+        )
+
+    def test_azure_abbreviations_points_to_correct_file(self, mkdocs_config):
+        azure_section = next(
+            (item["Azure"] for item in mkdocs_config["nav"] if "Azure" in item),
+            None,
+        )
+        abbrev_entry = next(
+            (e["Abbreviations"] for e in azure_section if "Abbreviations" in e),
+            None,
+        )
+        assert abbrev_entry == "azure/files/abbreviations/abbreviations.md", (
+            f"Azure Abbreviations nav points to '{abbrev_entry}', expected "
+            "'azure/files/abbreviations/abbreviations.md'"
+        )
+
+    def test_azure_abbreviations_before_exam_coverage(self, mkdocs_config):
+        azure_section = next(
+            (item["Azure"] for item in mkdocs_config["nav"] if "Azure" in item),
+            None,
+        )
+        entry_keys = [list(e.keys())[0] for e in azure_section]
+        abbrev_idx = entry_keys.index("Abbreviations")
+        exam_idx = entry_keys.index("Exam Coverage")
+        assert abbrev_idx < exam_idx, (
+            f"Abbreviations (index {abbrev_idx}) must come before "
+            f"Exam Coverage (index {exam_idx}) in Azure nav"
+        )
+
+
+class TestMkdocsNavAws:
+    """mkdocs.yml must have Abbreviations as first child under AWS."""
+
+    def test_aws_abbreviations_nav_entry_present(self, mkdocs_config):
+        aws_section = next(
+            (item["AWS"] for item in mkdocs_config["nav"] if "AWS" in item),
+            None,
+        )
+        assert aws_section is not None, "AWS nav section not found in mkdocs.yml"
+        entry_keys = [list(e.keys())[0] for e in aws_section]
+        assert "Abbreviations" in entry_keys, (
+            "Abbreviations entry not found in AWS nav block"
+        )
+
+    def test_aws_abbreviations_points_to_correct_file(self, mkdocs_config):
+        aws_section = next(
+            (item["AWS"] for item in mkdocs_config["nav"] if "AWS" in item),
+            None,
+        )
+        abbrev_entry = next(
+            (e["Abbreviations"] for e in aws_section if "Abbreviations" in e),
+            None,
+        )
+        assert abbrev_entry == "aws/files/abbreviations/abbreviations.md", (
+            f"AWS Abbreviations nav points to '{abbrev_entry}', expected "
+            "'aws/files/abbreviations/abbreviations.md'"
+        )
+
+    def test_aws_abbreviations_before_exam_coverage(self, mkdocs_config):
+        aws_section = next(
+            (item["AWS"] for item in mkdocs_config["nav"] if "AWS" in item),
+            None,
+        )
+        entry_keys = [list(e.keys())[0] for e in aws_section]
+        abbrev_idx = entry_keys.index("Abbreviations")
+        exam_idx = entry_keys.index("Exam Coverage")
+        assert abbrev_idx < exam_idx, (
+            f"Abbreviations (index {abbrev_idx}) must come before "
+            f"Exam Coverage (index {exam_idx}) in AWS nav"
+        )
+
+
+# ── Issue 4: Azure exams.md Abbreviations row ─────────────────────────────────
+
+
+class TestAzureExamsAbbreviationsRow:
+    """docs/azure/files/exams/exams.md must have Abbreviations as first data row."""
+
+    def test_abbreviations_row_present(self, azure_exams_text):
+        assert "[Abbreviations](../abbreviations/abbreviations.md)" in azure_exams_text
+
+    def test_abbreviations_is_first_data_row(self, azure_exams_text):
+        lines = azure_exams_text.splitlines()
+        data_rows = [
+            ln
+            for ln in lines
+            if ln.strip().startswith("|") and "---" not in ln and "Section" not in ln
+        ]
+        assert len(data_rows) > 0, "No data rows found in azure exams.md table"
+        assert "[Abbreviations]" in data_rows[0], (
+            f"First data row must be Abbreviations, got: {data_rows[0]}"
+        )
+
+    def test_abbreviations_row_has_dash_placeholders(self, azure_exams_text):
+        lines = azure_exams_text.splitlines()
+        for ln in lines:
+            if "[Abbreviations]" in ln and ln.strip().startswith("|"):
+                assert ln.count("| — |") >= 5 or ln.count("— |") >= 5, (
+                    f"Expected dash placeholders in abbreviations row: {ln}"
+                )
+                break
+
+
+# ── Issue 5: AWS exams.md Abbreviations row ───────────────────────────────────
+
+
+class TestAwsExamsAbbreviationsRow:
+    """docs/aws/files/exams/exams.md must have Abbreviations as first data row."""
+
+    def test_abbreviations_row_present(self, aws_exams_text):
+        assert "[Abbreviations](../abbreviations/abbreviations.md)" in aws_exams_text
+
+    def test_abbreviations_is_first_data_row(self, aws_exams_text):
+        lines = aws_exams_text.splitlines()
+        data_rows = [
+            ln
+            for ln in lines
+            if ln.strip().startswith("|") and "---" not in ln and "Section" not in ln
+        ]
+        assert len(data_rows) > 0, "No data rows found in aws exams.md table"
+        assert "[Abbreviations]" in data_rows[0], (
+            f"First data row must be Abbreviations, got: {data_rows[0]}"
+        )
+
+    def test_abbreviations_row_has_dash_placeholders(self, aws_exams_text):
+        lines = aws_exams_text.splitlines()
+        for ln in lines:
+            if "[Abbreviations]" in ln and ln.strip().startswith("|"):
+                assert ln.count("— |") >= 2, (
+                    f"Expected dash placeholders in abbreviations row: {ln}"
+                )
+                break


### PR DESCRIPTION
## Summary
Resolves #234 — FEATURE: Create an abbreviation section in each topic for all abbreviations found in the whole section
## Changes
- ### Issue 1
- ### Issue 2
- ### Issue 3
- ### Issue 4
- ### Issue 5

**Tasks:**
- Create `docs/azure/files/abbreviations/abbreviations.md` with heading `# ABBREVIATIONS`
- Scan all ten Azure domain files for capitalised abbreviations:
- Compile a deduplicated, alphabetically sorted Markdown table with columns
- Write the table into `docs/azure/files/abbreviations/abbreviations.md`
- Create `docs/aws/files/abbreviations/abbreviations.md` with heading `# ABBREVIATIONS`
- Scan all eleven AWS domain files for capitalised abbreviations:
- Write the table into `docs/aws/files/abbreviations/abbreviations.md`
- In `mkdocs.yml` under the `Azure:` nav block (currently line 61), insert
- In `mkdocs.yml` under the `AWS:` nav block (currently line 73), insert
- In `docs/azure/files/exams/exams.md`, insert a new first data row after
- In `docs/aws/files/exams/exams.md`, insert a new first data row after
- All existing and new tests pass locally (pytest / mvn test / npm test / etc.)
- All existing and new lint checks pass locally (ruff / eslint / ng lint / etc.)
- `make ci` passes with zero errors (markdownlint, mermaid-check, ruff, pytest, MkDocs strict build)
- `make docs-serve` renders both abbreviation pages and they are reachable
## Testing
Run the full test suite — all tests must pass.
Closes #234