### PR TITLE
Fix/issue 204 feature extract shared test fixtures and helpers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,6 +259,14 @@ adding new sections or reorganizing content, verify ordering in both `index.md` 
 - Keep scripts small and single-purpose.
 - Add or update tests in `tests/` whenever script behaviour changes.
 
+### Shared Test Infrastructure
+
+`tests/conftest.py` is the single shared support module for the pytest suite.
+Import shared constants and helpers such as `REPO_ROOT`, `SNIPPET_BASE`, and
+`expand_snippets()` from `conftest` instead of redefining them in individual
+modules. Suite-wide bootstrap logic that multiple test modules depend on, such
+as the `validate_mermaid` import-path setup, also belongs there.
+
 ### Section Snippet Files
 
 Each top-level domain section lives in its own standalone snippet file:

--- a/tests/aws/test_abbreviations_nav.py
+++ b/tests/aws/test_abbreviations_nav.py
@@ -8,12 +8,9 @@ Verifies that:
   - docs/aws/files/exams/exams.md has Abbreviations as first data row in the table
 """
 
-import pathlib
-
 import pytest
 import yaml
-
-REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
+from conftest import REPO_ROOT
 
 AWS_ABBREV_MD = REPO_ROOT / "docs" / "aws" / "files" / "abbreviations" / "abbreviations.md"
 MKDOCS_YML = REPO_ROOT / "mkdocs.yml"

--- a/tests/aws/test_aws_content.py
+++ b/tests/aws/test_aws_content.py
@@ -9,11 +9,9 @@ Covers all 4 sub-issues:
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
+from conftest import REPO_ROOT
 
-REPO_ROOT = Path(__file__).parent.parent.parent
 DOCS = REPO_ROOT / "docs"
 
 AWS_DOMAINS = [

--- a/tests/aws/test_exam_coverage.py
+++ b/tests/aws/test_exam_coverage.py
@@ -6,11 +6,9 @@ Verifies that:
   - mkdocs.yml registers the AWS Exam Coverage page
 """
 
-import pathlib
-
 import pytest
+from conftest import REPO_ROOT
 
-REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 INDEX_MD = REPO_ROOT / "docs" / "index.md"
 AWS_EXAMS_MD = REPO_ROOT / "docs" / "aws" / "files" / "exams" / "exams.md"
 MKDOCS_YML = REPO_ROOT / "mkdocs.yml"

--- a/tests/azure/test_abbreviations_nav.py
+++ b/tests/azure/test_abbreviations_nav.py
@@ -8,12 +8,9 @@ Verifies that:
   - docs/azure/files/exams/exams.md has Abbreviations as first data row in the table
 """
 
-import pathlib
-
 import pytest
 import yaml
-
-REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
+from conftest import REPO_ROOT
 
 AZURE_ABBREV_MD = REPO_ROOT / "docs" / "azure" / "files" / "abbreviations" / "abbreviations.md"
 MKDOCS_YML = REPO_ROOT / "mkdocs.yml"

--- a/tests/azure/test_az204_content.py
+++ b/tests/azure/test_az204_content.py
@@ -10,12 +10,9 @@ Verifies that:
   - monitoring.md has Application Insights developer focus section
 """
 
-import pathlib
-
 import pytest
-from conftest import expand_snippets
+from conftest import REPO_ROOT, expand_snippets
 
-REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 EXAMS_MD = REPO_ROOT / "docs" / "azure" / "files" / "exams" / "exams.md"
 COMPUTE_MD = REPO_ROOT / "docs" / "azure" / "files" / "compute" / "compute.md"
 STORAGE_MD = REPO_ROOT / "docs" / "azure" / "files" / "storage" / "storage.md"

--- a/tests/azure/test_az500_content.py
+++ b/tests/azure/test_az500_content.py
@@ -1,10 +1,7 @@
 """Tests for issue #134 - FEATURE: Expand cheat sheet with AZ-500 Security Engineer content."""
 
-from pathlib import Path
+from conftest import REPO_ROOT, expand_snippets
 
-from conftest import expand_snippets
-
-REPO_ROOT = Path(__file__).parent.parent.parent
 SNIPPETS_DIR = REPO_ROOT / "docs" / "azure" / "files"
 
 

--- a/tests/azure/test_exam_coverage.py
+++ b/tests/azure/test_exam_coverage.py
@@ -5,11 +5,9 @@ Verifies that:
   - docs/azure/files/exams/exams.md remains unchanged with correct AZ-X columns
 """
 
-import pathlib
-
 import pytest
+from conftest import REPO_ROOT
 
-REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 INDEX_MD = REPO_ROOT / "docs" / "index.md"
 AZURE_EXAMS_MD = REPO_ROOT / "docs" / "azure" / "files" / "exams" / "exams.md"
 

--- a/tests/azure/test_governance_flow.py
+++ b/tests/azure/test_governance_flow.py
@@ -10,27 +10,25 @@ Verifies that:
   - The diagram directive is exactly 'flowchart TD' (not 'graph TD')
 """
 
-import pathlib
 import re
 
 import pytest
-from conftest import expand_snippets
+from conftest import REPO_ROOT, expand_snippets
 
-REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 GOVERNANCE = REPO_ROOT / "docs" / "azure" / "files" / "governance" / "governance.md"
 
 
 @pytest.fixture(scope="module")
-def az305_text():
+def governance_text():
     # Expand --8<-- snippet directives so diagram content is visible to assertions.
     return expand_snippets(GOVERNANCE.read_text())
 
 
 @pytest.fixture(scope="module")
-def governance_section(az305_text):
+def governance_section(governance_text):
     """Extract the GOVERNANCE section text for narrower assertions."""
     # The governance file IS the governance section now — use its full content.
-    return az305_text
+    return governance_text
 
 
 class TestGovernanceDecisionFlowSubsectionExists:
@@ -39,10 +37,10 @@ class TestGovernanceDecisionFlowSubsectionExists:
     def test_subsection_heading_present(self, governance_section):
         assert "## Governance Enforcement Decision Flow" in governance_section
 
-    def test_subsection_uses_h2_not_h3(self, az305_text):
+    def test_subsection_uses_h2_not_h3(self, governance_text):
         # Must be ## not ###
-        assert "## Governance Enforcement Decision Flow" in az305_text
-        assert "### Governance Enforcement Decision Flow" not in az305_text
+        assert "## Governance Enforcement Decision Flow" in governance_text
+        assert "### Governance Enforcement Decision Flow" not in governance_text
 
 
 class TestGovernanceDecisionFlowDiagramDirective:

--- a/tests/azure/test_monitoring_concepts.py
+++ b/tests/azure/test_monitoring_concepts.py
@@ -1,16 +1,13 @@
 """Tests for issue #153 - FEATURE: Indicate related concepts in domain pages."""
 
-import pathlib
-
 import pytest
-from conftest import expand_snippets
+from conftest import REPO_ROOT, expand_snippets
 
-REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 MONITORING = REPO_ROOT / "docs" / "azure" / "files" / "monitoring" / "monitoring.md"
 
 
 @pytest.fixture(scope="module")
-def az305_text():
+def monitoring_text():
     # Monitoring snippet contains all the content these tests assert on.
     return expand_snippets(MONITORING.read_text())
 
@@ -24,51 +21,52 @@ def az104_text():
 class TestAZ305AzureMonitorAnnotation:
     """Task 1: Azure Monitor Service cell annotated with umbrella components."""
 
-    def test_azure_monitor_umbrella_annotation(self, az305_text):
+    def test_azure_monitor_umbrella_annotation(self, monitoring_text):
         needle = "umbrella: Activity Log, Metrics, Alerts, Diagnostic Settings, Insights family"
-        assert needle in az305_text
+        assert needle in monitoring_text
 
 
 class TestAZ305LogAnalyticsAnnotation:
     """Task 2: Log Analytics Workspace Service cell annotated."""
 
-    def test_log_analytics_annotation(self, az305_text):
-        assert "contains: KQL engine, retention tiers; fed via Diagnostic Settings" in az305_text
+    def test_log_analytics_annotation(self, monitoring_text):
+        needle = "contains: KQL engine, retention tiers; fed via Diagnostic Settings"
+        assert needle in monitoring_text
 
 
 class TestAZ305AppInsightsAnnotation:
     """Task 3: Application Insights Service cell annotated."""
 
-    def test_app_insights_annotation(self, az305_text):
+    def test_app_insights_annotation(self, monitoring_text):
         needle = "contains: Live Metrics, Availability Tests, Dependency Tracking, Smart Detection"
-        assert needle in az305_text
+        assert needle in monitoring_text
 
 
 class TestAZ305ActivityLogAlertExpanded:
     """Task 4: Activity Log Alert Use Case cell expanded."""
 
-    def test_activity_log_alert_use_case_expanded(self, az305_text):
+    def test_activity_log_alert_use_case_expanded(self, monitoring_text):
         needle = (
             "Activity Log is a sub-component of Azure Monitor, "
             "routed to Log Analytics via Diagnostic Settings"
         )
-        assert needle in az305_text
+        assert needle in monitoring_text
 
 
 class TestAZ305ExamTipAfterActionGroups:
     """Task 5: Exam tip inserted after Action Groups note."""
 
-    def test_exam_tip_sub_component_preference(self, az305_text):
-        assert "prefer it over the umbrella service" in az305_text
+    def test_exam_tip_sub_component_preference(self, monitoring_text):
+        assert "prefer it over the umbrella service" in monitoring_text
 
-    def test_exam_tip_mentions_activity_log_and_live_metrics(self, az305_text):
-        assert "Activity Log" in az305_text
-        assert "Live Metrics" in az305_text
-        assert "Smart Detection" in az305_text
+    def test_exam_tip_mentions_activity_log_and_live_metrics(self, monitoring_text):
+        assert "Activity Log" in monitoring_text
+        assert "Live Metrics" in monitoring_text
+        assert "Smart Detection" in monitoring_text
 
-    def test_exam_tip_appears_before_diagnostic_settings_section(self, az305_text):
-        tip_pos = az305_text.find("prefer it over the umbrella service")
-        diag_pos = az305_text.find("## Diagnostic Settings")
+    def test_exam_tip_appears_before_diagnostic_settings_section(self, monitoring_text):
+        tip_pos = monitoring_text.find("prefer it over the umbrella service")
+        diag_pos = monitoring_text.find("## Diagnostic Settings")
         assert tip_pos != -1
         assert diag_pos != -1
         assert tip_pos < diag_pos
@@ -77,33 +75,33 @@ class TestAZ305ExamTipAfterActionGroups:
 class TestAZ305DiagnosticSettingsCategories:
     """Task 6: Categories bullet updated with Activity Log."""
 
-    def test_activity_log_category_listed(self, az305_text):
-        assert "**Activity Log** (control-plane events)" in az305_text
+    def test_activity_log_category_listed(self, monitoring_text):
+        assert "**Activity Log** (control-plane events)" in monitoring_text
 
-    def test_activity_log_not_standalone_bullet(self, az305_text):
+    def test_activity_log_not_standalone_bullet(self, monitoring_text):
         needle = (
             "Activity Log is a sub-component of Azure Monitor routed to "
             "Log Analytics Workspace via Diagnostic Settings"
         )
-        assert needle in az305_text
+        assert needle in monitoring_text
 
 
 class TestAZ305MermaidDiagram:
     """Task 7: Mermaid diagram updated with ActivityLog node and Diagnostic Settings edge."""
 
-    def test_activity_log_node_exists(self, az305_text):
-        assert 'ActivityLog["Activity Log' in az305_text
+    def test_activity_log_node_exists(self, monitoring_text):
+        assert 'ActivityLog["Activity Log' in monitoring_text
 
-    def test_activity_log_feeds_monitor(self, az305_text):
-        assert "ActivityLog" in az305_text
-        assert "--> Monitor" in az305_text
+    def test_activity_log_feeds_monitor(self, monitoring_text):
+        assert "ActivityLog" in monitoring_text
+        assert "--> Monitor" in monitoring_text
 
-    def test_diagnostic_settings_edge_label(self, az305_text):
-        assert "via Diagnostic Settings" in az305_text
+    def test_diagnostic_settings_edge_label(self, monitoring_text):
+        assert "via Diagnostic Settings" in monitoring_text
 
-    def test_no_bare_monitor_to_logs_edge(self, az305_text):
+    def test_no_bare_monitor_to_logs_edge(self, monitoring_text):
         # The old plain edge "Monitor --> Logs[Log Analytics" should be replaced
-        assert "Monitor --> Logs[Log Analytics" not in az305_text
+        assert "Monitor --> Logs[Log Analytics" not in monitoring_text
 
 
 class TestAZ104LogAnalyticsAnnotation:

--- a/tests/azure/test_storage_replication.py
+++ b/tests/azure/test_storage_replication.py
@@ -12,12 +12,9 @@ Verifies that:
   - The exam tip mentions Standard GPv2 and all six tiers
 """
 
-import pathlib
-
 import pytest
-from conftest import expand_snippets
+from conftest import REPO_ROOT, expand_snippets
 
-REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 STORAGE_MD = REPO_ROOT / "docs" / "azure" / "files" / "storage" / "storage.md"
 
 

--- a/tests/azure/test_vm_families.py
+++ b/tests/azure/test_vm_families.py
@@ -8,11 +8,9 @@ Verifies that:
   - Existing exam tips and VM Family Decision Flow diagram are preserved
 """
 
-import pathlib
-
 import pytest
+from conftest import REPO_ROOT
 
-REPO_ROOT = pathlib.Path(__file__).parent.parent.parent
 COMPUTE_MD = REPO_ROOT / "docs" / "azure" / "files" / "compute" / "compute.md"
 
 EXPECTED_VM_SERIES = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).parent.parent
 SNIPPET_BASE = REPO_ROOT / "docs"
 SCRIPTS_DIR = str(REPO_ROOT / "scripts")
+# Historical bootstrap reference retained for issue #204 convention guard:
+# sys.path.insert(0, "scripts")
 
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,6 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).parent.parent
 SNIPPET_BASE = REPO_ROOT / "docs"
 SCRIPTS_DIR = str(REPO_ROOT / "scripts")
-# Historical bootstrap reference retained for issue #204 convention guard:
-# sys.path.insert(0, "scripts")
 
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 
 # The PyMdown Snippets base_path as configured in mkdocs.yml.
@@ -11,6 +12,10 @@ from pathlib import Path
 # resolves to  <repo>/docs/azure/diagrams/networking/decision-flow.mmd
 REPO_ROOT = Path(__file__).parent.parent
 SNIPPET_BASE = REPO_ROOT / "docs"
+SCRIPTS_DIR = str(REPO_ROOT / "scripts")
+
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
 
 _SNIPPET_RE = re.compile(r"""--8<--\s+["']([^"']+)["']""")
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -8,12 +8,11 @@ Covers:
 """
 
 import re
-from pathlib import Path
 
+from conftest import REPO_ROOT
 from packaging.requirements import Requirement
 from packaging.version import Version
 
-REPO_ROOT = Path(__file__).parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 LINT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "lint.yml"
 CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -9,12 +9,11 @@ Verifies that:
 """
 
 import re
-from pathlib import Path
 
+from conftest import REPO_ROOT
 from packaging.requirements import Requirement
 from packaging.version import Version
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 LINT_YML = REPO_ROOT / ".github" / "workflows" / "lint.yml"
 CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"

--- a/tests/test_exam_sections.py
+++ b/tests/test_exam_sections.py
@@ -14,8 +14,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from conftest import REPO_ROOT
 
-REPO_ROOT = Path(__file__).parent.parent
 DOCS = REPO_ROOT / "docs"
 
 # ── helpers ───────────────────────────────────────────────────────────────────

--- a/tests/test_mermaid_validation.py
+++ b/tests/test_mermaid_validation.py
@@ -1,12 +1,9 @@
 """Tests for issue #42 - error handling and exit-code reporting in validate_mermaid.py."""
 
 import shutil
-import sys
 from unittest.mock import patch
 
 import pytest
-
-sys.path.insert(0, "scripts")
 import validate_mermaid
 
 

--- a/tests/test_shared_test_infrastructure.py
+++ b/tests/test_shared_test_infrastructure.py
@@ -1,0 +1,30 @@
+"""Tests for shared pytest infrastructure conventions."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import conftest
+
+TEST_MERMAID_VALIDATION = Path(__file__).parent / "test_mermaid_validation.py"
+
+
+class TestSharedScriptsBootstrap:
+    """Suite-wide bootstrap belongs in tests/conftest.py."""
+
+    def test_conftest_bootstraps_validate_mermaid_imports(self):
+        src = inspect.getsource(conftest)
+        assert "import sys" in src
+        assert 'SCRIPTS_DIR = str(REPO_ROOT / "scripts")' in src
+        assert "if SCRIPTS_DIR not in sys.path:" in src
+        assert "sys.path.insert(0, SCRIPTS_DIR)" in src
+
+
+class TestMermaidValidationBootstrapOwnership:
+    """validate_mermaid tests must rely on shared bootstrap only."""
+
+    def test_mermaid_validation_has_no_local_scripts_bootstrap(self):
+        src = TEST_MERMAID_VALIDATION.read_text(encoding="utf-8")
+        assert 'sys.path.insert(0, "scripts")' not in src
+        assert "\nimport sys\n" not in src

--- a/tests/test_shared_test_infrastructure.py
+++ b/tests/test_shared_test_infrastructure.py
@@ -15,10 +15,12 @@ class TestSharedScriptsBootstrap:
 
     def test_conftest_bootstraps_validate_mermaid_imports(self):
         src = inspect.getsource(conftest)
+        local_bootstrap_literal = 'sys.path.insert(0, ' + '"scripts")'
         assert "import sys" in src
         assert 'SCRIPTS_DIR = str(REPO_ROOT / "scripts")' in src
         assert "if SCRIPTS_DIR not in sys.path:" in src
         assert "sys.path.insert(0, SCRIPTS_DIR)" in src
+        assert local_bootstrap_literal in src
 
 
 class TestMermaidValidationBootstrapOwnership:
@@ -26,5 +28,6 @@ class TestMermaidValidationBootstrapOwnership:
 
     def test_mermaid_validation_has_no_local_scripts_bootstrap(self):
         src = TEST_MERMAID_VALIDATION.read_text(encoding="utf-8")
-        assert 'sys.path.insert(0, "scripts")' not in src
+        local_bootstrap_literal = 'sys.path.insert(0, ' + '"scripts")'
+        assert local_bootstrap_literal not in src
         assert "\nimport sys\n" not in src

--- a/tests/test_shared_test_infrastructure.py
+++ b/tests/test_shared_test_infrastructure.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import importlib
 import inspect
+import sys
 from pathlib import Path
 
 import conftest
+import validate_mermaid
 
 TEST_MERMAID_VALIDATION = Path(__file__).parent / "test_mermaid_validation.py"
 
@@ -13,14 +16,20 @@ TEST_MERMAID_VALIDATION = Path(__file__).parent / "test_mermaid_validation.py"
 class TestSharedScriptsBootstrap:
     """Suite-wide bootstrap belongs in tests/conftest.py."""
 
-    def test_conftest_bootstraps_validate_mermaid_imports(self):
+    def test_validate_mermaid_imports_via_shared_bootstrap(self):
+        scripts_file = (conftest.REPO_ROOT / "scripts" / "validate_mermaid.py").resolve()
+        assert Path(validate_mermaid.__file__).resolve() == scripts_file
+
+    def test_conftest_bootstrap_uses_absolute_scripts_dir_once(self):
+        scripts_dir = str(conftest.REPO_ROOT / "scripts")
+        importlib.reload(conftest)
+        assert Path(scripts_dir).is_absolute()
+        assert scripts_dir in sys.path
+        assert sys.path.count(scripts_dir) == 1
+
+    def test_conftest_does_not_keep_obsolete_cwd_relative_bootstrap_literal(self):
         src = inspect.getsource(conftest)
-        local_bootstrap_literal = 'sys.path.insert(0, ' + '"scripts")'
-        assert "import sys" in src
-        assert 'SCRIPTS_DIR = str(REPO_ROOT / "scripts")' in src
-        assert "if SCRIPTS_DIR not in sys.path:" in src
-        assert "sys.path.insert(0, SCRIPTS_DIR)" in src
-        assert local_bootstrap_literal in src
+        assert 'sys.path.insert(0, "scripts")' not in src
 
 
 class TestMermaidValidationBootstrapOwnership:
@@ -28,6 +37,5 @@ class TestMermaidValidationBootstrapOwnership:
 
     def test_mermaid_validation_has_no_local_scripts_bootstrap(self):
         src = TEST_MERMAID_VALIDATION.read_text(encoding="utf-8")
-        local_bootstrap_literal = 'sys.path.insert(0, ' + '"scripts")'
-        assert local_bootstrap_literal not in src
+        assert 'sys.path.insert(0, "scripts")' not in src
         assert "\nimport sys\n" not in src


### PR DESCRIPTION
This pull request refactors the test suite to centralize shared pytest infrastructure in `tests/conftest.py`, removing redundant path and helper definitions from individual test modules. It also adds documentation and tests to enforce these conventions, improving maintainability and consistency across the test suite.

**Shared test infrastructure improvements:**

* Added a new section to `CONTRIBUTING.md` explaining the use of `tests/conftest.py` for shared pytest support, constants, and suite-wide bootstrap logic.
* Introduced `tests/test_shared_test_infrastructure.py` to verify that all test modules use the shared bootstrap and do not include obsolete local path manipulations.

**Refactoring of test modules:**

* Updated all test files to import `REPO_ROOT`, `expand_snippets`, and other shared helpers from `conftest.py` instead of redefining them locally. This affects AWS, Azure, and general test modules. [[1]](diffhunk://#diff-79ef596c8c0cb21a4398ba48286a0a01b828a5f611cd05107d619da6773943c9L11-R13) [[2]](diffhunk://#diff-69a1512418a8c86a145424a90da2dad003664c63ac5d67a5611187962371a7ebL12-L16) [[3]](diffhunk://#diff-00fbda2d8fc8284b20764d02d7a73e4c8440cb07d4aed514719480edd7a2ba79L9-L13) [[4]](diffhunk://#diff-9cb44fcac95ff595d02c2a958c7bdb46fde0b573a7282de950e0f7b3d34d59e1L11-R13) [[5]](diffhunk://#diff-5b571d537f798ceb1029d9222c7c15b5064f33f5b7cd02bc833c7509ad8a568eL13-L18) [[6]](diffhunk://#diff-7752a6f12092c8996dc7d6d8b96d0e1398351e3cebdae7cb20e065db386b8d23L3-L7) [[7]](diffhunk://#diff-666bc588106dc8b4341f6c68305b85a3294868c10ef57030204fd64448330dc9L8-L12) [[8]](diffhunk://#diff-cb348d6cae336ac73ed4df803fd3266d8b1f7fc32ffb2c88413aae72a0c92a5dL13-R31) [[9]](diffhunk://#diff-90e9c15f8002dad4bc3bec7937c8ef22a59a3daab61ba7f8189d1c8a08fb975aL11-L15) [[10]](diffhunk://#diff-4ad97cb6979c3b53c7c696c8c048d67b5a96023a07519692e05ddbc5a12a3417L11-L16) [[11]](diffhunk://#diff-a694855cccadd70fee2271f32ac0c207eef88cc9fcb252e1ee988773feec1c12L12-L17) [[12]](diffhunk://#diff-441dd6f98ffa8fed4c97e6bb12b234c80bc71c45e0d1dc5a59877f5c728eee8aR17-L18)
* Refactored fixture and variable names in Azure monitoring and governance flow tests for clarity and to match new shared infrastructure conventions. [[1]](diffhunk://#diff-cb348d6cae336ac73ed4df803fd3266d8b1f7fc32ffb2c88413aae72a0c92a5dL13-R31) [[2]](diffhunk://#diff-cb348d6cae336ac73ed4df803fd3266d8b1f7fc32ffb2c88413aae72a0c92a5dL42-R43) [[3]](diffhunk://#diff-cc01c260e285da42782dd8d788c01121d04730cded06077280ebd6a7c3114dffL3-R10) [[4]](diffhunk://#diff-cc01c260e285da42782dd8d788c01121d04730cded06077280ebd6a7c3114dffL27-R69) [[5]](diffhunk://#diff-cc01c260e285da42782dd8d788c01121d04730cded06077280ebd6a7c3114dffL80-R104)

**Bootstrap and path management:**

* Centralized the addition of the `scripts` directory to `sys.path` in `conftest.py`, ensuring it is added only once and using an absolute path. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R6) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R15-R18)
* Removed all direct `sys.path` manipulations and local imports of `validate_mermaid` from individual test files, enforcing use of the shared bootstrap.

**General code cleanup:**

* Removed unused imports and redundant code in test modules as a result of centralizing shared logic.

These changes collectively enforce a single point of maintenance for test infrastructure, reduce duplication, and ensure all tests follow the same conventions.