### PR TITLE
fix: resolve #224 - BUG: Wire up MMD_FILES_VALIDATE in Makefile and extend CI me

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -121,5 +121,5 @@ jobs:
         - name: Validate Mermaid diagrams
           run: |
             python3 scripts/validate_mermaid.py \
-              $(find docs/azure/files -name '*.md' | sort) \
-              $(find docs/azure/diagrams -name '*.mmd' | sort)
+              $(find docs/azure/files docs/aws/files -name '*.md' | sort) \
+              $(find docs/azure/diagrams docs/aws/diagrams -name '*.mmd' | sort)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ MD_FILES_VALIDATE := $(shell find docs -name '*.md' \
   ! -path 'docs/azure/diagrams/*' \
   ! -path 'docs/overrides/*')
 # All standalone .mmd diagram files
-MMD_FILES_VALIDATE := $(shell find docs/azure/diagrams -name '*.mmd' 2>/dev/null)
+MMD_FILES_VALIDATE := $(shell find docs/azure/diagrams docs/aws/diagrams -name '*.mmd' 2>/dev/null)
 
 # ── Phony declarations ─────────────────────────────────────────────────────────
 .PHONY: help venv install \
@@ -109,7 +109,7 @@ mermaid-check: puppeteer-config
 	npm audit --audit-level=high
 	PUPPETEER_CONFIG_FILE=$(PUPPETEER_CONFIG_FILE) \
 	  PATH="$(CURDIR)/node_modules/.bin:$(PATH)" \
-	  $(PY) scripts/validate_mermaid.py $(MD_FILES_VALIDATE)
+	  $(PY) scripts/validate_mermaid.py $(MD_FILES_VALIDATE) $(MMD_FILES_VALIDATE)
 
 # ── Python lint ───────────────────────────────────────────────────────────────
 python-lint: venv

--- a/tests/test_issue_224.py
+++ b/tests/test_issue_224.py
@@ -1,0 +1,63 @@
+"""Tests for issue #224: Wire up MMD_FILES_VALIDATE in Makefile and extend
+CI mermaid-check job to cover AWS diagrams.
+
+Verifies that:
+  - Makefile's MMD_FILES_VALIDATE find covers both docs/azure/diagrams and
+    docs/aws/diagrams
+  - Makefile's mermaid-check target forwards $(MMD_FILES_VALIDATE) to
+    scripts/validate_mermaid.py alongside $(MD_FILES_VALIDATE)
+  - .github/workflows/lint.yml "Validate Mermaid diagrams" step's find
+    invocations cover both docs/azure/{files,diagrams} and
+    docs/aws/{files,diagrams}
+"""
+
+import re
+
+from conftest import REPO_ROOT
+
+MAKEFILE = REPO_ROOT / "Makefile"
+LINT_YML = REPO_ROOT / ".github" / "workflows" / "lint.yml"
+
+
+class TestMakefileMmdFilesValidate:
+    """MMD_FILES_VALIDATE must cover azure and aws diagrams, and be wired in."""
+
+    def test_mmd_files_validate_covers_aws_diagrams(self):
+        content = MAKEFILE.read_text()
+        m = re.search(r"MMD_FILES_VALIDATE\s*:=\s*\$\(shell find ([^)]*?)-name '\*\.mmd'", content)
+        assert m, "Could not locate MMD_FILES_VALIDATE definition in Makefile"
+        find_paths = m.group(1)
+        assert "docs/azure/diagrams" in find_paths
+        assert "docs/aws/diagrams" in find_paths
+
+    def test_mermaid_check_forwards_mmd_files_validate(self):
+        content = MAKEFILE.read_text()
+        m = re.search(r"mermaid-check:.*?validate_mermaid\.py ([^\n]*)", content, re.S)
+        assert m, "Could not locate validate_mermaid.py invocation in mermaid-check target"
+        invocation_args = m.group(1)
+        assert "$(MD_FILES_VALIDATE)" in invocation_args
+        assert "$(MMD_FILES_VALIDATE)" in invocation_args
+
+
+class TestCiMermaidCheckAwsCoverage:
+    """CI 'Validate Mermaid diagrams' step must include docs/aws paths."""
+
+    def _step_block(self) -> str:
+        content = LINT_YML.read_text()
+        m = re.search(
+            r"Validate Mermaid diagrams.*?(?=\n\s*- name:|\Z)",
+            content,
+            re.S,
+        )
+        assert m, "Could not locate 'Validate Mermaid diagrams' step in lint.yml"
+        return m.group(0)
+
+    def test_md_find_covers_aws_files(self):
+        block = self._step_block()
+        assert "docs/azure/files" in block
+        assert "docs/aws/files" in block
+
+    def test_mmd_find_covers_aws_diagrams(self):
+        block = self._step_block()
+        assert "docs/azure/diagrams" in block
+        assert "docs/aws/diagrams" in block


### PR DESCRIPTION
This pull request expands Mermaid diagram validation to include AWS diagrams in both the Makefile and CI workflow, and adds tests to ensure this coverage remains in place. The most important changes are grouped below:

**Build and CI workflow improvements:**

* Updated the `Makefile` so that `MMD_FILES_VALIDATE` now includes both `docs/azure/diagrams` and `docs/aws/diagrams`, ensuring AWS diagrams are validated.
* Modified the `mermaid-check` target in the `Makefile` to pass both `$(MD_FILES_VALIDATE)` and `$(MMD_FILES_VALIDATE)` to `scripts/validate_mermaid.py`, ensuring all relevant files are checked.
* Updated the `.github/workflows/lint.yml` workflow to validate Mermaid diagrams in both Azure and AWS documentation paths (`docs/azure/files`, `docs/aws/files`, `docs/azure/diagrams`, `docs/aws/diagrams`).

**Test coverage:**

* Added `tests/test_issue_224.py`, which verifies that the Makefile and CI workflow correctly include AWS diagrams in Mermaid validation, guarding against regressions.