### PR TITLE
fix: resolve #271 - FEATURE: Add Programming section and add Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ answer "which one and why?" — not step-by-step tutorials or portal walkthrough
 |-------|
 | Microsoft Azure |
 | Amazon Web Services |
+| Programming (Java) |
 
 More topics (other cloud providers, DevOps tooling, architecture patterns) will be added over time.
 Each new topic lives under its own subdirectory inside `docs/`.

--- a/docs/programming/diagrams/java/collection-selection-decision-flow.mmd
+++ b/docs/programming/diagrams/java/collection-selection-decision-flow.mmd
@@ -1,0 +1,15 @@
+flowchart TD
+    A[Need a collection] --> B{Key-value pairs?}
+    B -- Yes --> C{Need insertion order?}
+    C -- Yes --> D[LinkedHashMap]
+    C -- No, need sorted keys --> E[TreeMap]
+    C -- No --> F[HashMap]
+    B -- No --> G{Duplicates allowed?}
+    G -- No --> H{Need sorted order?}
+    H -- Yes --> I[TreeSet]
+    H -- No, need insertion order --> J[LinkedHashSet]
+    H -- No --> K[HashSet]
+    G -- Yes --> L{Frequent index access?}
+    L -- Yes --> M[ArrayList]
+    L -- No, frequent insert/remove at ends --> N[ArrayDeque]
+    L -- No, frequent insert/remove in middle --> O[LinkedList]

--- a/docs/programming/files/java/java.md
+++ b/docs/programming/files/java/java.md
@@ -1,0 +1,226 @@
+# JAVA
+
+Quick-reference cheat sheet for Java, targeting the latest LTS release (**Java 21**).
+Comparison-oriented — covers language fundamentals, core OOP concepts, functional features,
+string idioms, and the JDBC/JPA/Lombok stack used in typical enterprise applications.
+
+## Language Basics & Keywords
+
+| Category | Keywords / Types | Key Feature |
+| --- | --- | --- |
+| Primitive types | `byte`, `short`, `int`, `long`, `float`, `double`, `char`, `boolean` | Stack-allocated, no autoboxing overhead unless used in generics/collections |
+| Access modifiers | `public`, `protected`, `private`, (package-private, no keyword) | Control visibility across package and inheritance boundaries |
+| Non-access modifiers | `static`, `final`, `abstract`, `synchronized`, `transient`, `volatile` | `final` = immutable reference/no override; `static` = class-level, not instance-level |
+| Control flow | `if/else`, `switch`, `for`, `while`, `do-while`, `for-each` | `switch` supports pattern matching and arrow syntax (`->`) since Java 14+ |
+| Exception handling | `try`, `catch`, `finally`, `throw`, `throws` | `try-with-resources` auto-closes `AutoCloseable` resources |
+| Records (Java 16+) | `record` | Immutable data carrier — auto-generates constructor, accessors, `equals`/`hashCode`/`toString` |
+| Sealed types (Java 17+) | `sealed`, `non-sealed`, `permits` | Restricts which classes/interfaces may extend/implement a type |
+| Text blocks (Java 15+) | `"""` | Multi-line string literals without escape-heavy concatenation |
+
+> **Exam tip:** `var` (Java 10+) is local-variable type inference only — it cannot be used for
+> fields, method parameters, or return types. The compiler still enforces static typing; `var`
+> is sugar, not dynamic typing.
+
+## Core OOP Concepts
+
+| Concept | Description | Key Feature |
+| --- | --- | --- |
+| **Encapsulation** | Bundling state and behaviour, exposing only what's needed via access modifiers | Private fields + public getters/setters (or records for immutable data) |
+| **Inheritance** | A class (`extends`) reuses and specialises another class's members | Single inheritance for classes; `super` accesses parent members |
+| **Polymorphism** | Same method signature, different runtime behaviour | Method overriding (runtime) vs overloading (compile-time) |
+| **Abstraction** | Expose behaviour contracts without exposing implementation details | Abstract classes and interfaces |
+
+### Interface vs Abstract Class
+
+| Aspect | Interface | Abstract Class |
+| --- | --- | --- |
+| Multiple inheritance | Yes — a class can implement several interfaces | No — a class extends only one abstract class |
+| State (instance fields) | No instance fields (only `static final` constants) | Can hold instance fields |
+| Constructors | Not allowed | Allowed |
+| Method bodies | `default` and `static` methods can have bodies (Java 8+) | Any method can have a body |
+| When to choose | Define a capability/contract shared across unrelated types | Share common state and partial implementation among closely related types |
+
+> **Exam tip:** Prefer interfaces for defining a contract implementable by unrelated classes;
+> prefer an abstract class when subclasses share common state or a partial implementation.
+
+## Lambda & Functional Interfaces
+
+| Interface | Method | Use Case |
+| --- | --- | --- |
+| `Function<T, R>` | `R apply(T t)` | Transform an input into an output |
+| `Predicate<T>` | `boolean test(T t)` | Boolean-valued condition, e.g. filtering |
+| `Consumer<T>` | `void accept(T t)` | Perform an action, no return value |
+| `Supplier<T>` | `T get()` | Provide/produce a value, no input |
+| `BiFunction<T, U, R>` | `R apply(T t, U u)` | Transform two inputs into an output |
+| `UnaryOperator<T>` | `T apply(T t)` | `Function<T, T>` specialisation |
+
+### Method References
+
+| Form | Example | Equivalent Lambda |
+| --- | --- | --- |
+| Static method | `Integer::parseInt` | `s -> Integer.parseInt(s)` |
+| Instance method (particular object) | `list::add` | `x -> list.add(x)` |
+| Instance method (arbitrary object of a type) | `String::toUpperCase` | `s -> s.toUpperCase()` |
+| Constructor | `ArrayList::new` | `() -> new ArrayList<>()` |
+
+### Streams Basics
+
+```java
+List<String> names = List.of("Bilbo", "Frodo", "Gandalf", "Aragorn");
+
+List<String> longNames = names.stream()
+    .filter(n -> n.length() > 5)
+    .map(String::toUpperCase)
+    .sorted()
+    .toList(); // Java 16+ terminal shortcut for Collectors.toList()
+```
+
+> **Exam tip:** Streams are lazily evaluated — intermediate operations (`filter`, `map`) only
+> execute once a terminal operation (`collect`, `toList`, `forEach`, `reduce`) is invoked.
+
+## String Manipulation
+
+Strings are **immutable** in Java — every "modifying" operation returns a new `String`.
+For heavy in-loop concatenation, prefer `StringBuilder` to avoid quadratic allocation cost.
+
+### String Reversal
+
+```java
+// StringBuilder — idiomatic, O(n)
+String reversed = new StringBuilder("Gandalf").reverse().toString();
+
+// char array swap — no intermediate object allocation per step
+char[] chars = "Gandalf".toCharArray();
+for (int i = 0, j = chars.length - 1; i < j; i++, j--) {
+    char tmp = chars[i];
+    chars[i] = chars[j];
+    chars[j] = tmp;
+}
+String reversedManual = new String(chars);
+```
+
+### Common Idioms
+
+| Task | Idiom |
+| --- | --- |
+| Join strings | `String.join(", ", list)` |
+| Check blank/empty | `str.isBlank()` (Java 11+) vs `str.isEmpty()` |
+| Repeat | `"ab".repeat(3)` → `"ababab"` (Java 11+) |
+| Format | `"%s is %d".formatted(name, age)` (Java 15+) |
+| Compare ignoring case | `str.equalsIgnoreCase(other)` |
+
+> **Exam tip:** `StringBuilder` is not thread-safe; `StringBuffer` is the synchronized
+> equivalent. Choose `StringBuilder` unless multiple threads mutate the same buffer.
+
+## JDBC
+
+JDBC (Java Database Connectivity) is the low-level API for direct SQL access.
+
+```java
+String url = "jdbc:postgresql://localhost:5432/mydb";
+try (Connection conn = DriverManager.getConnection(url, user, password);
+     PreparedStatement stmt = conn.prepareStatement(
+         "SELECT id, name FROM users WHERE id = ?")) {
+    stmt.setLong(1, userId);
+    try (ResultSet rs = stmt.executeQuery()) {
+        while (rs.next()) {
+            System.out.println(rs.getString("name"));
+        }
+    }
+}
+```
+
+| Statement Type | Use Case | Key Feature |
+| --- | --- | --- |
+| `Statement` | Static SQL with no parameters | No parameter binding — vulnerable to SQL injection if concatenating input |
+| `PreparedStatement` | Parameterised, repeatable queries | Pre-compiled; safe parameter binding; better performance for repeated execution |
+| `CallableStatement` | Invoking stored procedures | Supports IN/OUT/INOUT parameters |
+
+> **Exam tip:** Always use `PreparedStatement` (or higher) when any part of the SQL includes
+> user input — parameter binding prevents SQL injection that string concatenation invites.
+
+## JPA
+
+JPA (Jakarta Persistence API) is the ORM specification implemented by providers such as
+Hibernate and EclipseLink, mapping Java objects to relational rows declaratively.
+
+```java
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    // getters/setters omitted
+}
+```
+
+```java
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByName(String name);
+
+    @Query("SELECT u FROM User u WHERE u.name LIKE %:term%")
+    List<User> searchByName(@Param("term") String term);
+}
+```
+
+### JDBC vs JPA
+
+| Aspect | JDBC | JPA |
+| --- | --- | --- |
+| Abstraction level | Low-level SQL execution | Object-relational mapping |
+| Boilerplate | High — manual result-set mapping | Low — entities mapped via annotations |
+| Query language | Raw SQL | JPQL (object-graph aware) or native SQL |
+| Caching | None built-in | First-level (session) and optional second-level cache |
+| Performance control | Full manual control | Abstracted — requires care to avoid N+1 queries |
+| When to choose | Fine-grained performance tuning, simple scripts, no ORM overhead desired | Rich domain models, rapid development, relationship-heavy schemas |
+
+> **Exam tip:** JPQL queries operate on entity object graphs, not table/column names directly —
+> `SELECT u FROM User u` refers to the `User` entity class, not the `users` table.
+
+## Lombok
+
+Lombok is an annotation processor that generates boilerplate (getters, setters, constructors,
+`equals`/`hashCode`, builders) at compile time, reducing repetitive code in POJOs and entities.
+
+| Annotation | Key Feature |
+| --- | --- |
+| `@Getter` / `@Setter` | Generates accessor/mutator methods for all (or annotated) fields |
+| `@ToString` | Generates a `toString()` implementation |
+| `@EqualsAndHashCode` | Generates `equals()`/`hashCode()` based on fields |
+| `@NoArgsConstructor` | Generates a no-argument constructor |
+| `@AllArgsConstructor` | Generates a constructor with all fields as parameters |
+| `@RequiredArgsConstructor` | Generates a constructor for `final`/`@NonNull` fields only |
+| `@Data` | Bundles `@Getter`, `@Setter`, `@ToString`, `@EqualsAndHashCode`, `@RequiredArgsConstructor` |
+| `@Builder` | Generates a fluent builder for object construction |
+| `@Slf4j` | Injects a preconfigured `Logger` field named `log` |
+
+```java
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDto {
+    private Long id;
+    private String name;
+}
+```
+
+> **Exam tip:** `@Data` is a convenience bundle, not a silver bullet — avoid it on JPA `@Entity`
+> classes where `equals`/`hashCode` based on all mutable fields (rather than the identifier) can
+> break collection semantics once an entity is persisted and its ID is assigned.
+
+## Collection Type Selection
+
+```mermaid
+--8<-- "programming/diagrams/java/collection-selection-decision-flow.mmd"
+```
+
+> **Exam tip:** `ArrayList` gives O(1) indexed access but O(n) insert/remove in the middle;
+> `LinkedList` gives O(1) insert/remove at known positions but O(n) indexed access. Choose based
+> on whether the workload is index-lookup-heavy or mutation-heavy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,8 @@ markdown_extensions:
 nav:
   - Home: index.md
   # Always alphabetically order top-level sections for easier navigation and maintenance.
+  - Programming:
+    - Java: programming/files/java/java.md
   - Cloud Service Providers:
     - AWS:
         - Abbreviations: aws/files/abbreviations/abbreviations.md

--- a/tests/test_issue_271.py
+++ b/tests/test_issue_271.py
@@ -1,0 +1,125 @@
+"""Tests for issue #271: FEATURE: Add Programming section and add Java.
+
+Verifies that:
+  - docs/programming/files/java/java.md exists with # JAVA heading and the
+    required sub-sections (Language Basics & Keywords, Core OOP Concepts,
+    Lambda & Functional Interfaces, String Manipulation, JDBC, JPA, Lombok).
+  - mkdocs.yml has a new top-level "Programming" nav group, alphabetically
+    ordered before "Cloud Service Providers", with a "Java" entry pointing to
+    programming/files/java/java.md.
+  - README.md's "Current Content" table has a Programming/Java row.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from conftest import REPO_ROOT
+
+JAVA_MD = REPO_ROOT / "docs" / "programming" / "files" / "java" / "java.md"
+MKDOCS_YML = REPO_ROOT / "mkdocs.yml"
+README_MD = REPO_ROOT / "README.md"
+
+REQUIRED_SECTIONS = [
+    "## Language Basics & Keywords",
+    "## Core OOP Concepts",
+    "## Lambda & Functional Interfaces",
+    "## String Manipulation",
+    "## JDBC",
+    "## JPA",
+    "## Lombok",
+]
+
+
+@pytest.fixture(scope="module")
+def java_text():
+    return JAVA_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def mkdocs_config():
+    # mkdocs.yml uses !!python/name: tags that yaml.safe_load cannot handle.
+    loader_class = yaml.SafeLoader
+
+    def _python_name_constructor(loader, tag_suffix, node):
+        return loader.construct_scalar(node)
+
+    loader_class.add_multi_constructor(
+        "tag:yaml.org,2002:python/name:",
+        _python_name_constructor,
+    )
+    return yaml.load(MKDOCS_YML.read_text(), Loader=loader_class)
+
+
+@pytest.fixture(scope="module")
+def readme_text():
+    return README_MD.read_text(encoding="utf-8")
+
+
+class TestJavaFileExists:
+    def test_file_exists(self):
+        assert JAVA_MD.exists(), f"{JAVA_MD} does not exist — create it with # JAVA heading"
+
+
+class TestJavaHeading:
+    def test_heading_present(self, java_text):
+        assert "# JAVA" in java_text
+
+
+class TestJavaRequiredSections:
+    @pytest.mark.parametrize("section", REQUIRED_SECTIONS)
+    def test_section_present(self, java_text, section):
+        assert section in java_text, f"Expected section '{section}' not found in java.md"
+
+
+class TestJavaMentionsLTS:
+    def test_mentions_java_21(self, java_text):
+        assert "Java 21" in java_text
+
+
+class TestMkdocsProgrammingNav:
+    def test_programming_group_present(self, mkdocs_config):
+        keys = [next(iter(item.keys())) for item in mkdocs_config["nav"] if isinstance(item, dict)]
+        assert "Programming" in keys, "Programming nav group not found"
+
+    def test_programming_before_cloud_service_providers(self, mkdocs_config):
+        keys = [next(iter(item.keys())) for item in mkdocs_config["nav"] if isinstance(item, dict)]
+        programming_idx = keys.index("Programming")
+        csp_idx = keys.index("Cloud Service Providers")
+        assert programming_idx < csp_idx, (
+            "Programming nav group must come before Cloud Service Providers "
+            "(alphabetical top-level ordering)"
+        )
+
+    def test_java_entry_present_under_programming(self, mkdocs_config):
+        programming_section = next(
+            (item["Programming"] for item in mkdocs_config["nav"] if "Programming" in item),
+            None,
+        )
+        assert programming_section is not None, "Programming nav section missing"
+        entry_keys = [next(iter(e.keys())) for e in programming_section]
+        assert "Java" in entry_keys
+
+    def test_java_entry_points_to_correct_file(self, mkdocs_config):
+        programming_section = next(
+            (item["Programming"] for item in mkdocs_config["nav"] if "Programming" in item),
+            None,
+        )
+        java_entry = next(
+            (e["Java"] for e in programming_section if "Java" in e),
+            None,
+        )
+        assert java_entry == "programming/files/java/java.md"
+
+
+class TestReadmeCurrentContent:
+    def test_java_row_present(self, readme_text):
+        lines = readme_text.splitlines()
+        data_rows = [
+            ln
+            for ln in lines
+            if ln.strip().startswith("|") and "---" not in ln and "Topic" not in ln
+        ]
+        assert any("Java" in row or "Programming" in row for row in data_rows), (
+            "Expected a Programming/Java row in README.md's Current Content table"
+        )


### PR DESCRIPTION
## Summary
Resolves #271 — FEATURE: Add Programming section and add Java
## Changes
- No `docs/programming/` directory, Java content, or Java cheat sheet exists in the codebase. Per `AGENTS.md`'s "Repository Layout" and "Content Conventions" sections, new topics must live under their own subdirectory inside `docs/` using the `files/<section>/<section>.md` snippet-page pattern (e.g. `
- The `nav:` block currently defines only one top-level content group, "Cloud Service Providers" (line 61), containing "AWS" (line 62) and "Azure" (line 76) sub-sections. There is no "Programming" group or "Java" entry, so the new cheat sheet page would not appear in the site navigation even after bei
- The "Current Content" table (lines 14-17) lists only `Microsoft Azure` and `Amazon Web Services`. The "Repository Structure" section (lines 22-39) also documents only the `docs/azure/` layout and section-directory list, with no mention of `docs/programming/`.

**Tasks:**
- Create `docs/programming/files/java/java.md` with `# JAVA` top-level heading.
- Add `## Language Basics & Keywords` section covering primitive types, keywords, syntax
- Add `## Core OOP Concepts` section (encapsulation, inheritance, polymorphism, abstraction,
- Add `## Lambda & Functional Interfaces` section (built-in functional interfaces, method
- Add `## String Manipulation` section with idiomatic examples (e.g. string reversal).
- Add `## JDBC` section (connection, PreparedStatement, comparison table where relevant).
- Add `## JPA` section (entities, repositories, JPQL, comparison vs plain JDBC).
- Add `## Lombok` section (common annotations, key features table).
- Target the latest Java LTS version (Java 21) throughout; no dedicated deprecation-warning
- Follow `Service`/`Key Feature`-style comparison tables and `> **Exam tip:**` callouts only
- If a genuine decision-style comparison is needed (e.g. collection type selection, JDBC vs
- Add a new top-level `Programming` group to `mkdocs.yml` `nav:` (lines 58-90), alphabetically
- Add a `Java` entry under `Programming` pointing to `programming/files/java/java.md`.
- Add a `Java` (or `Programming`) row to the "Current Content" table in `README.md`
- All existing and new tests pass locally (pytest / mvn test / npm test / etc.)
- All existing and new lint checks pass locally (ruff / eslint / ng lint / etc.)
## Testing
Run the full test suite — all tests must pass.
Closes #271