### PR TITLE
fix: resolve #239 - FEATURE: Add Google Cloud Cheat Sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ answer "which one and why?" — not step-by-step tutorials or portal walkthrough
 
 | Topic |
 |-------|
-| Microsoft Azure |
-| Amazon Web Services |
-| Programming (Java) |
+|| Microsoft Azure |
+|| Amazon Web Services |
+|| Google Cloud |
+|| Programming (Java) |
 
 More topics (other cloud providers, DevOps tooling, architecture patterns) will be added over time.
 Each new topic lives under its own subdirectory inside `docs/`.
@@ -31,6 +32,16 @@ docs/
       <slug>.mmd                — exam-agnostic slug
     files/<section>/            — shared section snippet files
       <section>.md              — e.g. networking/networking.md
+  aws/
+    files/
+      <domain>/<domain>.md       — One page per domain (compute, networking, …)
+    diagrams/<section>/
+      <slug>.mmd
+  google/
+    files/
+      <domain>/<domain>.md       — One page per domain (compute, networking, …)
+    diagrams/<section>/
+      <slug>.mmd
   index.md                      — MkDocs site home page
 mkdocs.yml                      — MkDocs Material site configuration
 ```

--- a/docs/google/diagrams/compute/compute-decision.mmd
+++ b/docs/google/diagrams/compute/compute-decision.mmd
@@ -1,0 +1,32 @@
+flowchart TD
+    Start[Choose a compute option in Google Cloud] --> Q1{Do you need full OS / VM-level control?}
+
+    Q1 -->|Yes| Q2{Do you need custom runtime or just a container?}
+    Q2 -->|Custom runtime, lift-and-shift| CE[Cloud Compute Engine VMs]
+    Q2 -->|Container, no orchestration| GCA[Cloud Run — serverless containers]
+    Q2 -->|Full K8s API| GKE[Google Kubernetes Engine]
+
+    Q1 -->|No| Q3{Is it code, or a container?}
+    Q3 -->|Code / function| Q4{Duration and concurrency profile?}
+    Q4 -->|Short-lived, event-driven| CF[Cloud Functions — single request functions]
+    Q4 -->|Longer-running, streaming| CF2[Cloud Functions (2nd gen) or Cloud Run]
+    Q4 -->|Microservice, custom runtime| CR[Cloud Run]
+
+    Q3 -->|Container| Q5{Scale-to-zero needed?}
+    Q5 -->|Yes| CR2[Cloud Run]
+    Q5 -->|No| GKE2[GKE Autopilot or Standard]
+
+    Q1 -->|No| Q6{Full web app framework / PaaS?}
+    Q6 -->|Yes — standard web framework| GAE[App Engine standard or flexible]
+    Q6 -->|No — see above| CR3[Cloud Run]
+
+    CE --> End[Deploy and configure networking / IAM]
+    GCA --> End
+    GKE --> End
+    CF --> End
+    CF2 --> End
+    CR --> End
+    CR2 --> End
+    GKE2 --> End
+    GAE --> End
+    CR3 --> End

--- a/docs/google/diagrams/identity/identity-decision.mmd
+++ b/docs/google/diagrams/identity/identity-decision.mmd
@@ -1,0 +1,26 @@
+flowchart TD
+    Start[Choose Google Cloud identity & access approach] --> Q1{Who are the identities?}
+
+    Q1 -->|Human users — workforce| Q2{On-prem AD exists?}
+    Q2 -->|Yes — hybrid| DCI[Cloud Identity — sync with on-prem AD via Google Cloud Directory Sync]
+    Q2 -->|No — cloud-only| CI[Cloud Identity — standalone cloud identity]
+
+    Q1 -->|Human users — customers/partners| CI2[Cloud Identity or third-party IdP via SAML/OIDC]
+
+    Q1 -->|Workloads — service-to-service| Q3{Google Cloud resource or external?}
+    Q3 -->|Google Cloud resource| SA[Service Account — dedicated identity for the workload]
+    Q3 -->|GKE workload| WI[Workload Identity — map K8s SA to IAM SA]
+    Q3 -->|External workload| EXTERN[Service Account with key or workload identity federation]
+
+    Q1 -->|Fine-grained access control| Q4{Resource-level permissions needed?}
+    Q4 -->|Yes — IAM Conditions, roles| IAM[Cloud IAM — roles, policies, conditions]
+    Q4 -->|No — basic roles| IAM2[Cloud IAM predefined roles]
+
+    DCI --> End[Configure SSO, MFA, device policies]
+    CI --> End
+    CI2 --> End
+    SA --> End[Grant least-privilege IAM roles to the SA]
+    WI --> End
+    EXTERN --> End
+    IAM --> End
+    IAM2 --> End

--- a/docs/google/diagrams/networking/networking-decision.mmd
+++ b/docs/google/diagrams/networking/networking-decision.mmd
@@ -1,0 +1,33 @@
+flowchart TD
+    Start[Choose Google Cloud networking service] --> Q1{Global or regional traffic?}
+
+    Q1 -->|Global — users worldwide| Q2{HTTP/S content delivery?}
+    Q2 -->|Yes — static/dynamic content| GCDN[Cloud CDN — edge cache for GCS, Compute Engine, GKE]
+    Q2 -->|Yes — global HTTP load balancing| GCLB[Cloud Load Balancing — global HTTP(S) LB]
+    Q2 -->|No — non-HTTP or TCP/UDP global| GCGLB[Global TCP/UDP LB or Cloud VPN/Interconnect]
+
+    Q1 -->|Regional — single region| Q3{HTTP/S or TCP/UDP?}
+    Q3 -->|HTTP/S| RCLB[Regional HTTP(S) Load Balancer]
+    Q3 -->|TCP/UDP| RCLB2[Regional TCP/UDP Load Balancer]
+    Q3 -->|Internal only| ICLB[Internal HTTP(S) LB or Network LB]
+
+    Q1 -->|DNS resolution| Q4{Public or private?}
+    Q4 -->|Public — internet-facing| CDNS[Cloud DNS — managed public DNS]
+    Q4 -->|Private — VPC-internal| CPDNS[Cloud DNS private zones / Cloud NAT for outbound]
+
+    Q1 -->|Connectivity to on-prem| Q5{Bandwidth and SLA needs?}
+    Q5 -->|High bandwidth, SLA-backed| DC[Cloud Interconnect — dedicated connection]
+    Q5 -->|Moderate, over internet| CVPN[Cloud VPN — IPSec over internet]
+    Q5 -->|Outbound internet from private instances| CNAT[Cloud NAT — managed NAT for private subnets]
+
+    GCLB --> End[Configure backends, health checks, SSL]
+    GCDN --> End
+    GCGLB --> End
+    RCLB --> End
+    RCLB2 --> End
+    ICLB --> End
+    CDNS --> End
+   CPDNS --> End
+    DC --> End
+    CVPN --> End
+    CNAT --> End

--- a/docs/google/diagrams/storage/storage-decision.mmd
+++ b/docs/google/diagrams/storage/storage-decision.mmd
@@ -1,0 +1,36 @@
+flowchart TD
+    Start[Choose Google Cloud storage/data service] --> Q1{Data type and access pattern?}
+
+    Q1 -->|Unstructured objects — files, images, backups| Q2{Access frequency?}
+    Q2 -->|Frequent| GCS_STD[Cloud Storage Standard class]
+    Q2 -->|Infrequent| GCS_NEARLINE[Cloud Storage Nearline — 30-day min]
+    Q2 -->|Rare, archive| GCS_COLDLINE[Cloud Storage Coldline — 90-day min]
+    Q2 -->|Long-term archival| GCS_ARCHIVE[Cloud Storage Archive — 365-day min]
+
+    Q1 -->|Block storage — VM boot/data disks| PD[Persistent Disk — balanced, SSD, extreme SSD]
+
+    Q1 -->|File shares — NFS/SMB, lift-and-shift| FS[Filestore — managed NFS, Basic/High Scale/Enterprise]
+
+    Q1 -->|Relational — structured OLTP| Q3{Transactional or analytical?}
+    Q3 -->|Transactional OLTP| SPANNER[Cloud Spanner — globally consistent, horizontal scale]
+    Q3 -->|Transactional, regional| ALLOYDB[AlloyDB — PostgreSQL-compatible, high performance]
+    Q3 -->|Transactional, MySQL-compatible| CLOUDSQL[Cloud SQL — managed MySQL/PostgreSQL/SQL Server]
+
+    Q1 -->|NoSQL — wide-column, high throughput| BT[Cloud Bigtable — low-latency wide-column store]
+
+    Q1 -->|NoSQL — document, mobile/web app| FB[Firestore — document DB, real-time sync, offline]
+
+    Q1 -->|Analytics — OLAP, data warehouse| BQ[BigQuery — serverless DW, SQL over petabytes]
+
+    GCS_STD --> End[Choose replication: regional, dual-region, multi-region]
+    GCS_NEARLINE --> End
+    GCS_COLDLINE --> End
+    GCS_ARCHIVE --> End
+    PD --> End
+    FS --> End
+    SPANNER --> End
+    ALLOYDB --> End
+    CLOUDSQL --> End
+    BT --> End
+    FB --> End
+    BQ --> End

--- a/docs/google/files/abbreviations/abbreviations.md
+++ b/docs/google/files/abbreviations/abbreviations.md
@@ -1,0 +1,59 @@
+# ABBREVIATIONS
+
+Centralised reference for every capitalised abbreviation used across the Google Cloud
+cheat-sheet sections (compute, networking, storage, identity, security, monitoring, messaging, governance, ha-dr, waf).
+
+| Abbreviation | Definition |
+| --- | --- |
+| GCP | Google Cloud Platform — Google's public cloud offering |
+| GCE | Compute Engine — IaaS VM service |
+| GKE | Google Kubernetes Engine — managed Kubernetes |
+| GCM | Cloud Monitoring — metrics, dashboards, alerting |
+| GCL | Cloud Logging — centralised log aggregation |
+| GCR | Container Registry — private Docker/OCI image registry (legacy, migrate to Artifact Registry) |
+| GAR | Artifact Registry — unified package and container registry |
+| ALB | Application Load Balancer — L7 HTTP(S) load balancing |
+| NLB | Network Load Balancer — L4 TCP/UDP load balancing |
+| GLBC | Global Load Balancer — anycast HTTP(S) LB with global frontend |
+| VPC | Virtual Private Cloud — isolated software-defined network |
+| CDN | Cloud CDN — edge caching for GCS, Compute Engine, GKE |
+| NAT | Cloud NAT — managed SNAT for private subnet instances |
+| DNS | Cloud DNS — managed authoritative DNS |
+| IAM | Cloud IAM — identity and access management |
+| SA | Service Account — identity for workloads, not humans |
+| WI | Workload Identity — map GKE Kubernetes service accounts to IAM service accounts |
+| SCC | Security Command Center — threat detection and security posture |
+| KMS | Cloud KMS — managed encryption key service |
+| SM | Secret Manager — secure secret storage and versioning |
+| BA | Binary Authorization — sign and verify container images before deployment |
+| VPC-SC | VPC Service Controls — perimeter-based data exfiltration protection |
+| ORC | Organization Policy — constrain GCP resource configurations |
+| RM | Resource Manager — project, folder, organization hierarchy |
+| BUD | Billing Budget — spend threshold alerts and actions |
+| PAI | Policy Troubleshooter — diagnose IAM grant/deny decisions |
+| CIAI | Cloud Asset Inventory — resource and policy inventory across projects |
+| HA | High Availability — eliminate single points of failure |
+| DR | Disaster Recovery — restore operations after catastrophic failure |
+| RT | Region — geographic deployment zone (e.g. us-central1) |
+| ZT | Zone — isolated failure domain within a region |
+| RR | Regional Resource — scoped to a single region |
+| MRR | Multi-Regional Resource — replicated across multiple regions |
+| RDB | Cloud SQL — managed relational database (MySQL, PostgreSQL, SQL Server) |
+| AD | AlloyDB — PostgreSQL-compatible, high-performance analytical/operational DB |
+| SP | Cloud Spanner — globally consistent, horizontally scalable relational DB |
+| BT | Cloud Bigtable — low-latency wide-column NoSQL store |
+| FS | Firestore — document NoSQL with real-time sync |
+| BQ | BigQuery — serverless data warehouse for analytics |
+| CS | Cloud Storage — object storage service |
+| PD | Persistent Disk — block storage for VM instances |
+| FILL | Filestore — managed NFS file shares |
+| PUB | Pub/Sub — asynchronous messaging and event ingestion |
+| EV | Eventarc — event ingestion and delivery to Cloud Run, GKE, Workflows |
+| WK | Workflows — serverless workflow orchestration (YAML-based) |
+| CT | Cloud Tasks — managed HTTP task queue for asynchronous retryable work |
+| MON | Cloud Monitoring — metrics, dashboards, Uptime Checks, Alerting |
+| LOG | Cloud Logging — log aggregation, exclusion, sinks |
+| TRC | Cloud Trace — distributed tracing for latency analysis |
+| PRF | Cloud Profiler — CPU and memory profiling of production services |
+| DBG | Cloud Debugger — inspect production application state without stopping |
+| WEF | Well-Architected Framework — Google Cloud architectural guidance pillars |

--- a/docs/google/files/compute/compute.md
+++ b/docs/google/files/compute/compute.md
@@ -1,0 +1,55 @@
+# COMPUTE
+
+## Compute Options
+
+| Service | Type | Best For | Key Feature |
+| --- | --- | --- | --- |
+| **Compute Engine** | IaaS VM | Full OS control, custom images, lift-and-shift | Persistent disks, SSH access, custom machine types, sole tenancy |
+| **Google Kubernetes Engine (GKE)** | Managed Kubernetes | Container orchestration at scale | Autopilot, standard mode, multi-cluster ingress, built-in service mesh (Istio) |
+| **Cloud Run** | Serverless containers | Event-driven, HTTP-serving containers with scale-to-zero | Per-request billing, Knative-based, any language/runtime in a container |
+| **Cloud Functions** | Serverless functions | Event-driven, single-purpose code | 1st gen (lightweight triggers), 2nd gen (Cloud Run-based, longer timeouts, more memory) |
+| **App Engine** | PaaS | Standard web frameworks, zero-ops deployment | Standard environment (sandboxed, fast scale) and Flexible environment (custom Docker) |
+
+> **Exam tip:** Choose Compute Engine when the requirement mentions custom OS, kernel-level tuning, or running existing binary workloads without containerisation. Choose GKE when Kubernetes-native orchestration, custom CNI, or complex microservice deployment topologies are needed. Choose Cloud Run when you need scale-to-zero for HTTP or event-driven containers without managing servers. Choose Cloud Functions when the workload is a single-purpose function reacting to events (pub/sub, storage, HTTP webhook). Choose App Engine when the application uses a supported standard framework (Python, Java, Go, Node, Ruby, .NET) and you want zero infrastructure management.
+
+## Compute Decision Flow
+
+```mermaid
+--8<-- "google/diagrams/compute/compute-decision.mmd"
+```
+
+> **Exam tip:** Start from the control plane question — full OS (Compute Engine) vs container orchestration (GKE) vs serverless containers (Cloud Run) vs functions (Cloud Functions) vs PaaS web app (App Engine). Containerised workloads that do not need the full Kubernetes API surface default to Cloud Run unless scale-to-zero is not required and steady-state capacity must be reserved — in that case GKE Autopilot is the more cost-efficient choice for predictable load.
+
+## Compute Engine Machine Families
+
+| Family | Optimised For | Example Use Case |
+| --- | --- | --- |
+| **General Purpose (N2, N2D, E2)** | Balanced CPU/memory | Web servers, application servers, dev/test |
+| **Compute Optimised (C2, C2D)** | High-performance CPU | Batch processing, game servers, simulation |
+| **Memory Optimised (M1, M2)** | Large in-memory datasets | In-memory caches, databases, SAP |
+| **Accelerator (GPU, TPU)** | ML training/inference, graphics | GPU (NVIDIA), TPU for TensorFlow/ML workloads |
+
+> **Exam tip:** E2 instances are cost-optimised general-purpose VMs with shared-core options — choose them for non-latency-sensitive dev/test. N2/N2D offer configurable vCPU and memory ratios. C2/C2D deliver the highest performance per core for tightly coupled compute. TPU is the answer when the requirement specifically mentions TensorFlow or JAX training at scale.
+
+## GKE Autopilot vs Standard
+
+| Dimension | Autopilot | Standard |
+| --- | --- | --- |
+| **Node management** | Fully managed — Google provisions and manages nodes | Customer manages node pools, upgrades, and sizing |
+| **Pod resource model** | Declare pod CPU/memory requests; system handles the rest | Full control over node shape, taints, tolerations, daemonsets |
+| **Scaling trigger** | Cluster autoscaler on pod pending | Cluster autoscaler on node pool; HPA on pods |
+| **Best for** | Teams that want Kubernetes without node ops | Teams that need custom node configuration, GPU/node-level tuning, or daemonsets |
+
+> **Exam tip:** GKE Autopilot is the safer default for greenfield Kubernetes workloads — it removes node-level operational burden. Choose Standard when you need node-level customisation (custom images, specific OS, GPU node pools, daemonsets, or node taints/tolerations for specialised workloads).
+
+## Cloud Run vs Cloud Functions
+
+| Dimension | Cloud Run | Cloud Functions (2nd gen) |
+| --- | --- | --- |
+| **Unit of deployment** | Container image (any runtime) | Source code or container (function framework) |
+| **Invocation** | HTTP request, Cloud Pub/Sub, Cloud Events | Event triggers, HTTP |
+| **Max execution** | 60 minutes | 60 minutes (2nd gen) |
+| **Concurrency** | Multiple requests per instance (configurable) | One request per instance |
+| **Scale-to-zero** | Yes | Yes |
+
+> **Exam tip:** Choose Cloud Run when the workload needs a custom runtime, multiple requests per instance, or an existing container image. Choose Cloud Functions when the workload is a small, event-driven piece of code with minimal dependencies and the built-in trigger integrations (Storage, Pub/Sub, Firestore) are sufficient.

--- a/docs/google/files/exams/exams.md
+++ b/docs/google/files/exams/exams.md
@@ -1,0 +1,15 @@
+# Exam Track Index
+
+|| Section | Cloud Digital Leader | Associate Cloud Engineer | Professional Cloud Architect | Professional Data Engineer | Professional DevOps Engineer |
+| --- | --- | --- | --- | --- | --- |
+| [Abbreviations](../abbreviations/abbreviations.md) | — | — | — | — | — |
+| [Compute](../compute/compute.md) | Partial | Full | Full | — | Full |
+| [Networking](../networking/networking.md) | Partial | Full | Full | — | Full |
+| [Storage](../storage/storage.md) | Partial | Full | Full | Full | Partial |
+| [Identity & Access](../identity/identity.md) | Partial | Full | Full | — | Full |
+| [Security](../security/security.md) | Partial | Full | Full | — | Full |
+| [Monitoring & Observability](../monitoring/monitoring.md) | — | Partial | Full | — | Full |
+| [Messaging & Integration](../messaging/messaging.md) | — | Partial | Full | Full | Full |
+| [Governance](../governance/governance.md) | — | Partial | Full | — | Full |
+| [High Availability & DR](../ha-dr/ha-dr.md) | — | Partial | Full | — | Partial |
+| [Well-Architected Framework](../waf/waf.md) | — | — | Full | — | — |

--- a/docs/google/files/governance/governance.md
+++ b/docs/google/files/governance/governance.md
@@ -1,0 +1,65 @@
+# GOVERNANCE
+
+## Core Governance Services
+
+| Service | Type | Best For | Key Feature |
+| --- | --- | --- | --- |
+| **Organization Policy** | Constraint enforcement | Enforce GCP resource configuration rules at org/folder/project level | Predefined constraints (e.g. restrict regions, disable APIs, enforce VM IM) and custom constraints (via Common Expression Language) |
+| **Resource Manager** | Resource hierarchy | Organise projects into folders and organisations; IAM inheritance | Organisation → Folder → Project hierarchy; IAM policies inherited down the tree |
+| **Cloud Asset Inventory** | Resource and policy inventory | Audit, compliance, and cost analysis across projects | Export current asset state to Cloud Storage, BigQuery, or Pub/Sub; asset search API |
+| **Billing Budgets** | Cost alerts and actions | Set spend thresholds; trigger notifications and actions when exceeded | Percentage thresholds (e.g. 50%, 90%, 100%); notification channels; programmatic actions via Cloud Functions/webhooks |
+| **Policy Troubleshooter** | IAM grant/deny diagnosis | Understand why a principal can or cannot access a resource | Shows which roles, conditions, and deny policies affect a specific permission decision |
+| **IAM Recommender** | Unused permission insight | Reduce overly broad roles | Role recommendations based on actual API usage; permissions·강세 analysis |
+
+> **Exam tip:** Organization Policy constraints are the answer when the requirement mentions enforcing a rule that blocks or audits resource configurations across projects or folders — for example, restricting resource locations to specific regions, disabling public IP on VMs, or enforcing that all VMs use a specific service account. Resource Manager provides the hierarchy; IAM policies inherit down the tree (organisation → folder → project). Cloud Asset Inventory provides a point-in-time or continuous inventory of all resources and IAM policies — it is the foundation for audit and compliance tooling.
+
+## Organization Policy Constraints
+
+| Constraint Type | Example | Description |
+| --- | --- | --- |
+| **List constraint** | `constraints/compute.trustedImageProjects` | Allow or deny a list of values (e.g. allowed image projects) |
+| **Boolean constraint** | `constraints/compute.disableNestedVirtualization` | On/off toggle for a feature |
+| **Custom constraint** | CEL expression on resource fields | Define your own condition (e.g. all VMs must have a firewall rule allowing only approved ports) |
+| **Override** | Per-folder or per-project exemption | Allow a child scope to override a constraint inherited from above |
+
+> **Exam tip:** List constraints enumerate allowed or denied values; boolean constraints toggle a feature. Custom constraints use the Common Expression Language (CEL) to express conditions on resource properties — they are more powerful but also more complex. If a constraint is set at the organisation level, it applies to all projects and folders unless overridden at a child scope.
+
+## Resource Hierarchy
+
+| Level | Purpose |
+| --- | --- |
+| **Organisation** | Root of the hierarchy — represents the company; organisation-level IAM and org policies apply to all |
+| **Folder** | Intermediate grouping — organise by department, environment, or team; inherit IAM and policies from parent |
+| **Project** | Lowest-level billable and IAM-scoped unit — resources live inside projects; project-level IAM and policies apply to resources in that project |
+
+> **Exam tip:** IAM policies inherit from parent to child — an organisation-level role grant is inherited by all folders and projects below it. A deny policy at any level overrides any allow at any level. Use folders to group projects by lifecycle, team, or environment for scalable policy and IAM management.
+
+## Billing Budgets
+
+| Feature | Detail |
+| --- | --- |
+| **Threshold alerts** | Trigger at 50%, 90%, 100%, or custom percentage of budget |
+| **Notification channels** | Email, Pub/Sub, webhook |
+| **Programmatic actions** | Trigger a Cloud Function or webhook when a threshold is crossed — for example, shut down non-essential resources, alert an on-call engineer |
+| **Budget scope** | Apply to a billing account or to specific projects |
+
+> **Exam tip:** Billing budgets are the answer when the requirement mentions alerting when spend exceeds a threshold or taking automated action when a budget limit is approached. Budgets can drive actions via Pub/Sub + Cloud Functions — for example, automatically stopping non-production VMs when spend hits 90% of budget.
+
+## Cloud Asset Inventory
+
+| Capability | Detail |
+| --- | --- |
+| **Export** | Export current asset state to Cloud Storage (bulk), BigQuery (queryable), or Pub/Sub (streaming) |
+| **Search** | Query assets by type, name, labels, and IAM policy |
+| **Coverage** | Includes resources, IAM policies, and VPC service controls perimeters |
+
+> **Exam tip:** Cloud Asset Inventory is the answer when the requirement mentions auditing resources or IAM policies across multiple projects — it provides a unified export that can be queried in BigQuery or exported to Cloud Storage for compliance storage. Asset Inventory does not enforce policy — it is a read-only inventory and search tool. Policy enforcement is done by Organization Policy.
+
+## IAM Recommender and Policy Troubleshooter
+
+| Service | What It Does |
+| --- | --- |
+| **IAM Recommender** | Analyzes actual API usage over a window and recommends removing unused permissions or replacing overly broad roles with narrower predefined roles |
+| **Policy Troubleshooter** | Answers "why can this principal access (or not access) this resource?" — shows which roles, conditions, and deny policies contributed to the decision |
+
+> **Exam tip:** Use IAM Recommender to right-size permissions and move toward least privilege. Use Policy Troubleshooter when a user reports access issues — it shows the exact allow/deny path so you can fix the policy without guessing.

--- a/docs/google/files/ha-dr/ha-dr.md
+++ b/docs/google/files/ha-dr/ha-dr.md
@@ -1,0 +1,88 @@
+# HIGH AVAILABILITY & DISASTER RECOVERY
+
+## Key Concepts
+
+| Term | Definition |
+| --- | --- |
+| **RTO** | Recovery Time Objective — maximum acceptable downtime |
+| **RPO** | Recovery Point Objective — maximum acceptable data loss (measured in time) |
+| **SLA** | Service Level Agreement — uptime commitment per service |
+| **Region** | Geographic deployment zone (e.g. us-central1, europe-west1) |
+| **Zone** | Isolated failure domain within a region (e.g. us-central1-a, us-central1-b, us-central1-c) |
+| **Regional resource** | Scoped to a single region (e.g. Cloud SQL instance, Persistent Disk) |
+| **Multi-regional resource** | Replicated across multiple regions (e.g. Cloud Storage multi-region, Cloud Spanner multi-region) |
+| **Region pair** | Google-paired regions for DR (not always symmetric — check pairing) |
+
+> **Exam tip:** A regional resource (Cloud SQL, Persistent Disk, Cloud Run region) survives zone failure if it is configured for regional redundancy, but not a full region failure. A multi-regional resource (Cloud Storage multi-region, Spanner multi-region) survives a full region failure. Know the difference — it is a common discriminator.
+
+## High Availability Patterns
+
+| Pattern | Scope | Best For | Key Feature |
+| --- | --- | --- | --- |
+| **Multi-zone (within a region)** | Regional, multiple zones | Surviving a single zone failure | Regional Cloud SQL, Cross-zone Load Balancing, Regional Persistent Disk |
+| **Multi-region (active-active)** | Multiple regions, both serving traffic | Near-zero RTO/RPO, global user base | Cloud Load Balancing global anycast, Cloud Spanner multi-region, Cloud Storage multi-region |
+| **Multi-region (active-passive)** | Primary region active, secondary on standby | Controlled cost, recovery within minutes to hours | Cloud DNS failover, Traffic Director multi-cluster, VM image replication |
+| **Backup and Restore** | Scheduled backups, restore when needed | Cost-optimised DR, smallest RPO/RTO requirements | Cloud SQL automated backups, Persistent Disk snapshots, Cloud Storage object versioning and lifecycle |
+|| **Pilot Light** | Minimal standby | Hours RTO, cost-optimised | Core data replicated, services off until needed |
+
+> **Exam tip:** Multi-zone within a region protects against a single zone failure. Multi-region active-active protects against a full region failure. Backup and Restore is the cheapest DR pattern — it provides recoverability but with the longest RTO (restore time). Match the pattern to the stated RTO and RPO.
+
+## Cloud Load Balancing Failover
+
+| Scenario | Mechanism |
+| --- | --- |
+| **Global HTTP(S) LB** | Anycast IP routes to the nearest healthy backend; if a region’s backends are unhealthy, traffic automatically routes to the next healthy region |
+| **Cross-region failover** | Health checks on backend buckets or instance groups trigger failover; no DNS change required for HTTP(S) traffic |
+| **Internal TCP/UDP LB** | Regional only — does not provide cross-region failover by itself; combine with Cloud DNS failover or Traffic Director |
+
+> **Exam tip:** The global HTTP(S) Load Balancer provides automatic regional failover based on health checks — no DNS changes needed. This is the answer when the requirement mentions seamless failover for HTTP/S traffic across regions. For TCP/UDP workloads, you need a different approach — Cloud DNS failover or Traffic Director.
+
+## Cloud DNS Failover
+
+| Feature | Detail |
+| --- | --- |
+| **Health-checked failover** | Cloud DNS monitors the health of primary and secondary endpoints; returns the primary IP if healthy, otherwise the secondary |
+| **TTL** | Low TTL (e.g. 60 seconds) recommended for fast failover; clients re-resolve DNS |
+| **Geolocation-based routing** | Return different IPs based on client location — not failover per se, but can direct users to the nearest region |
+
+> **Exam tip:** Cloud DNS failover is the answer when the requirement mentions DNS-based failover to a secondary region — it works for any protocol (not only HTTP/S) because it operates at the DNS level. For automatic, health-check-driven failover of HTTP/S traffic, the global HTTP(S) LB is preferred (no DNS dependency).
+
+## Persistent Disk and Snapshot DR
+
+| Mechanism | Scope | RPO | RTO |
+| --- | --- | --- | --- |
+| **Regional Persistent Disk** | Synchronous replication across two zones in a region | Near zero (synchronous) | Automatic failover within the region |
+| **Persistent Disk snapshots** | Asynchronous, stored in Cloud Storage | Depends on snapshot schedule | Restore by creating a new disk from snapshot — minutes to hours |
+| **Snapshot schedule** | Automated recurring snapshots | Controlled by schedule frequency | Same as manual snapshot restore |
+
+> **Exam tip:** Regional Persistent Disk provides synchronous replication across two zones — it survives a zone failure with near-zero RPO and automatic failover. Snapshots are asynchronous — they provide a point-in-time copy for DR but with RPO depending on the schedule. Snapshots stored in Cloud Storage can be restored in another region to support region-level DR.
+
+## Cloud SQL DR
+
+| Option | Scope | RPO | RTO |
+| --- | --- | --- | --- |
+| **HA configuration (regional)** | Same region, standby in another zone | Near zero (synchronous) | Automatic failover, seconds to minutes |
+| **Read replica (cross-region)** | Async replica in another region | Seconds to minutes (async) | Promote replica to primary — minutes |
+| **Backups and restore** | Backup stored in Cloud Storage | Depends on backup schedule | Restore to a new instance — minutes to hours |
+
+> **Exam tip:** Cloud SQL HA configuration provides automatic zone-failure failover within a region. Cross-region read replicas can be promoted for region-level DR, but RPO is not zero because replication is asynchronous. For strict RPO requirements, choose synchronous replication (regional HA or Cloud Spanner multi-region).
+
+## Cloud Spanner Replication
+
+| Configuration | Scope | Consistency | Use Case |
+| --- | --- | --- | --- |
+| **Regional** | Single region, three zones | Strong | Regional OLTP with high availability |
+| **Dual-region** | Two regions | Strong (synchronous) | Low-latency multi-region OLTP within a continent |
+| **Multi-region** | Three or more regions | Strong (synchronous) | Global OLTP with strongest consistency |
+
+> **Exam tip:** Cloud Spanner is the only GCP relational database that provides globally synchronous replication with strong consistency — it is the answer when the requirement mentions global OLTP with strong consistency across regions. The trade-off is higher cost and write latency (synchronous replication across regions adds round-trip time).
+
+## Cloud Storage DR
+
+| Replication | Scope | Durability | Availability |
+| --- | --- | --- | --- |
+| **Regional** | Single region, multiple zones | 99.999999999% (11 9s) within region | Survives zone failure |
+| **Dual-region** | Two regions in same continent | 11 9s | Survives one region failure; low-latency read from either region |
+| **Multi-region** | Three or more regions globally | 11 9s | Highest availability; global read access; eventual consistency for overwrites across regions |
+
+> **Exam tip:** Cloud Storage multi-region provides the highest availability and durability — it survives a full region failure. For DR planning, ensure the bucket is configured as multi-region or dual-region if the requirement mentions surviving a region outage. Object versioning and lifecycle policies provide an additional layer of protection against accidental deletion or overwrite.

--- a/docs/google/files/identity/identity.md
+++ b/docs/google/files/identity/identity.md
@@ -1,0 +1,56 @@
+# IDENTITY & ACCESS
+
+## Core Identity Services
+
+| Service | Type | Best For | Key Feature |
+| --- | --- | --- | --- |
+| **Cloud IAM** | Access control | Fine-grained permissions across GCP resources | Predefined and custom roles, IAM Conditions, deny policies |
+| **Cloud Identity** | User and device management | Workforce identity, device policy enforcement | Directory sync, SSO, endpoint management, no Google Workspace licence required |
+| **Service Account** | Workload identity | Application and service-to-service authentication | JSON key (legacy) or workload identity federation; no human credential |
+| **Workload Identity** | GKE workload auth | Map Kubernetes service accounts to IAM service accounts | No node-level service account key; pod-level identity; least-privilege per deployment |
+| **Identity-Aware Proxy (IAP)** | Zero-trust access | Secure access to internal apps without VPN | Context-aware access, Beyond Corp model, no network perimeter |
+
+> **Exam tip:** Choose Cloud IAM for any access control requirement — it is the central authorisation plane for all GCP resources. Prefer predefined roles over custom roles unless the requirement explicitly needs a tailored permission set. Service accounts are the correct identity for workloads; never use personal user credentials for application auth. Workload Identity is the preferred pattern for GKE workloads — it eliminates service account key management on nodes.
+
+## Cloud IAM Roles
+
+| Role Type | Description | Example |
+| --- | --- | --- |
+| **Primitive roles** | Broad, legacy roles at project level | Viewer, Editor, Owner |
+| **Predefined roles** | Service-specific, granular permissions | Compute Admin, Storage Object Viewer |
+| **Custom roles** | Tailored permission set (if predefined is insufficient) | Subset of permissions for a specific job function |
+| **Deny policies** | Explicitly deny actions regardless of allow roles | Block region, block action type, block Public IP creation |
+
+> **Exam tip:** Primitive roles (Viewer, Editor, Owner) grant overly broad permissions — use predefined or custom roles for production. IAM Conditions let you restrict role grants by attribute (e.g. request time window, IP range, resource tag). Deny policies are evaluated first — an explicit deny overrides any allow.
+
+## Service Account vs Workload Identity
+
+| Dimension | Service Account (key-based) | Workload Identity (GKE) |
+| --- | --- | --- |
+| **Credential type** | JSON key file (long-lived) | Underlying IAM SA mapped from K8s SA |
+| **Key rotation** | Manual (key expiry) | Automatic — no key to rotate |
+| **Granularity** | Node-level SA or per-pod key | Per-pod, per-deployment identity |
+| **Security posture** | Keys can be leaked, over-privileged | No keys; pod identity tied to K8s SA |
+
+> **Exam tip:** Workload Identity is the recommended authentication pattern for GKE workloads. Avoid long-lived service account keys — they are a security risk (hard to rotate, can be exfiltrated). Use Workload Identity or workload identity federation for workloads running outside GCP.
+
+## Cloud Identity
+
+| Use Case | Feature |
+| --- | --- |
+| **Workforce SSO** | Integrate with existing IdP via SAML or OIDC, or use Cloud Identity as the directory |
+| **Device management** | Enforce screen lock, encryption, compliance policies on endpoints |
+| **Directory sync** | Google Cloud Directory Sync (GCDS) syncs on-prem AD/LDAP to Cloud Identity |
+| **No Workspace licence required** | Cloud Identity is a standalone identity and device management product — a Workspace licence is not required for workforce SSO and device policy |
+
+> **Exam tip:** Cloud Identity is the answer when the requirement mentions workforce identity with device management but does not require Google Workspace collaboration features (Drive, Gmail, Calendar). Cloud Identity provides SSO, directory sync, and endpoint management without a Workspace subscription.
+
+## Identity-Aware Proxy (IAP)
+
+| Scenario | How IAP Helps |
+| --- | --- |
+| **Access internal web apps** | Users authenticate once via Google identity; no VPN required |
+| **Access Compute Engine / GKE / Cloud Run** | TCP or HTTP(S) tunnel to private instances with identity-based policy |
+| **Beyond Corp zero-trust** | Access decisions based on user identity and context, not network location |
+
+> **Exam tip:** IAP satisfies requirements that mention accessing internal applications without exposing them to the public internet and without a VPN. IAP is the Google Cloud implementation of the Beyond Corp zero-trust access model — network location does not grant access; identity + context does.

--- a/docs/google/files/messaging/messaging.md
+++ b/docs/google/files/messaging/messaging.md
@@ -1,0 +1,70 @@
+# MESSAGING & INTEGRATION
+
+## Messaging and Event Services
+
+| Service | Type | Best For | Key Feature |
+| --- | --- | --- | --- |
+| **Pub/Sub** | Asynchronous messaging | Event ingestion, fan-out, decoupling, streaming pipelines | At-least-once delivery, message ordering per ordering key, push and pull delivery, replay (retention 1–365 days), exactly-once delivery (with subscription-levelack deadline extension) |
+| **Eventarc** | Event ingestion and delivery | Bring your own event sources; deliver to Cloud Run, GKE, Workflows, Cloud Functions | Pre-built triggers for GCP event sources; third-party event sources; CloudEvents schema |
+| **Workflows** | Workflow orchestration (serverless) | Multi-step sequences calling GCP APIs and services | YAML-based definitions, retry policies, GET/POST/HTTP calls, parallel execution |
+| **Cloud Tasks** | HTTP task queue | Managed retryable HTTP work, rate limiting, dispatch | Task queue with retry, HEAD/GET/POST/PUT/PATCH/DELETE targets, rate controls, dispatch deadline |
+| **API Gateway** | API management | REST API front-end with auth, quotas, traffic management | OpenAPI spec, request/response transformation, API keys, Cloud Monitoring integration |
+
+> **Exam tip:** Choose Pub/Sub when the requirement mentions high-throughput asynchronous messaging, event ingestion, or decoupled producers and consumers with replay capability. Choose Eventarc when the requirement mentions ingesting events from GCP services or third-party SaaS and delivering them to serverless targets with CloudEvents formatting. Choose Workflows when the requirement mentions orchestrating a multi-step process that coordinates calls to GCP APIs or HTTP endpoints — it is YAML-based and serverless, not a code-based orchestrator. Choose Cloud Tasks when the requirement mentions dispatching and retrying HTTP requests with rate limiting — it is a managed Task Queue for HTTP targets. Choose API Gateway when the requirement mentions exposing a REST API with request validation, API keys, and quota enforcement.
+
+## Pub/Sub Characteristics
+
+| Feature | Detail |
+| --- | --- |
+| **Delivery guarantee** | At-least-once (default); exactly-once with subscription-level acknowledgement deadline extension and dead-lettering |
+| **Ordering** | Ordering keys — messages with the same ordering key are delivered in order; one ordering key per publisher/ subscriber combination |
+| **Retention and replay** | Retain acknowledged messages for 1–365 days; replay by seeking the subscription cursor |
+| **Push vs pull** | Push — Pub/Sub HTTP pushes messages to subscribers; Pull — subscriber polls with lease management |
+| **Dead-lettering** | Messages that exceed max delivery attempts or dead-letter explicitly move to a dead-letter topic |
+
+> **Exam tip:** Pub/Sub ordering keys guarantee per-key FIFO ordering — but only within a single publisher and subscriber; ordering is not global. For global ordering, you must partition by ordering key and process each partition sequentially. Exactly-once delivery is supported with additional configuration — it is not the default; the default is at-least-once with possible duplicates, so subscribers should be idempotent.
+
+## Eventarc
+
+| Feature | Detail |
+| --- | --- |
+| **GCP event sources** | Pre-built triggers for Cloud Storage, Pub/Sub, Firestore, BigQuery, and many other GCP services |
+| **Third-party events** | Partner and custom event sources via CloudEvents schema |
+| **Targets** | Cloud Run, GKE (with CloudEvents sink), Cloud Functions, Workflows |
+| **CloudEvents** | Standardised event format (type, source, id, subject, data) |
+
+> **Exam tip:** Eventarc is the answer when the requirement mentions reacting to GCP service events (e.g. a file uploaded to Cloud Storage, a Firestore document created) without writing custom polling or trigger integration — Eventarc provides pre-built triggers for many GCP services. Eventarc uses CloudEvents as the standard event schema, making it interoperable with non-GCP consumers.
+
+## Workflows
+
+| Feature | Detail |
+| --- | --- |
+| **Definition** | YAML-based workflow definition — steps, conditions, retries, parallelism |
+| **Integration** | Call Google Cloud APIs (Compute Engine, Cloud SQL, BigQuery, etc.), HTTP endpoints, serverless targets |
+| **State management** | Built-in state; results from one step can feed the next |
+| **Error handling** | Retry policies, conditional error branches, exception handling |
+
+> **Exam tip:** Workflows is the answer when the requirement mentions orchestrating a multi-step business process that spans GCP services and/or HTTP endpoints in a serverless, YAML-defined workflow — not a message-driven choreographed architecture. It is not a Kubernetes-native orchestrator (use Cloud Composer / Airflow for that) and not a code-based function orchestrator (use Cloud Functions or Cloud Run with Dapr or custom logic).
+
+## Cloud Tasks
+
+| Feature | Detail |
+| --- | --- |
+| **Task queue** | Queues of HTTP tasks with retry, rate limiting, and dispatch deadline |
+| **Target** | Any HTTP endpoint — can be Cloud Run, GKE, Compute Engine, or external |
+| **Rate controls** | Concurrency limit, rate limit (tasks per second) |
+| **Retry** | Configurable retry count, max interval, min interval, backoff |
+
+> **Exam tip:** Cloud Tasks is the answer when the requirement mentions a managed queue for retryable HTTP work — for example, sending emails, calling webhooks, or dispatching jobs to a fleet of workers with rate control. Unlike Pub/Sub, Cloud Tasks targets a specific HTTP endpoint directly and supports sophisticated retry and rate-limit configurations.
+
+## Pub/Sub vs Eventarc vs Cloud Tasks
+
+| Dimension | Pub/Sub | Eventarc | Cloud Tasks |
+| --- | --- | --- | --- |
+| **Model** | Asynchronous messaging — producer pushes to topic, subscribers consume | Event ingestion — sources fire events, Eventarc routes to targets | HTTP task queue — enqueue HTTP requests, workers dequeue and process |
+| **Replay** | Yes — seek subscription cursor | No — events are delivered once | No — tasks are consumed and deleted on success or dead-lettered |
+| **Topologies** | Many-to-many pub/sub | Many-to-one or many-to-many event routing | One-to-one task dispatch |
+| **Protocols** | gRPC streaming, HTTP push/pull | CloudEvents over HTTP/webhook | HTTP target (outbound from Cloud Tasks) |
+| **Best for** | High-throughput event streaming, replay, buffering | Reacting to GCP or SaaS events with pre-built triggers | Dispatching and retrying HTTP work with rate control |
+
+> **Exam tip:** The three services are complementary, not competing. Pub/Sub is for high-volume event streaming with replay. Eventarc is for reacting to GCP and SaaS events with minimal glue code. Cloud Tasks is for dispatch and retry of HTTP work. If the requirement mentions replay, choose Pub/Sub. If it mentions reacting to a GCP service event without custom polling, choose Eventarc. If it mentions dispatching HTTP requests with retry and rate control, choose Cloud Tasks.

--- a/docs/google/files/monitoring/monitoring.md
+++ b/docs/google/files/monitoring/monitoring.md
@@ -1,0 +1,65 @@
+# MONITORING & OBSERVABILITY
+
+## Core Observability Services
+
+| Service | Type | Best For | Key Feature |
+| --- | --- | --- | --- |
+| **Cloud Monitoring** | Metrics, dashboards, alerting | Resource and application metrics, uptime checks, alerting policies | Metrics Explorer, dashboards, uptime checks, alert policies with notification channels |
+| **Cloud Logging** | Log aggregation, search, sinks | Centralised log collection, exclusion, export | Log Explorer, log-based metrics, exclusion filters, export sinks to Pub/Sub, GCS, BigQuery |
+| **Cloud Trace** | Distributed tracing | Latency analysis across service boundaries | Latency distribution, trace spans, integration with Cloud Run, GKE, App Engine |
+| **Cloud Profiler** | CPU and memory profiling | Production performance analysis without stopping service | CPU and heap profiles, flame graphs, low overhead agent |
+| **Cloud Debugger** | Production state inspection | Inspect variables and call stack without stopping the service | Snapshot and logpoints, no code redeploy needed |
+
+> **Exam tip:** Cloud Monitoring answers "what is happening with my resources and apps right now" — metrics, dashboards, uptime. Cloud Logging answers "what did my system emit" — log aggregation, query, export. Cloud Trace answers "which call is slow" — distributed latency across microservices. Cloud Profiler answers "where is CPU/memory going" — production flame graphs. Cloud Debugger answers "what are the variables at this line" — without redeploying or stopping the service.
+
+## Cloud Monitoring Metrics
+
+| Metric Type | Scope | Use Case |
+| --- | --- | --- |
+| **System metrics** | Resource-level (CPU, memory, disk, network) | Infrastructure health monitoring |
+| **Custom metrics** | Application-defined | Business KPIs, queue depth, custom events |
+| **Log-based metrics** | Derived from Cloud Logging | Count/aggregation of log entries matching a filter |
+| **Uptime checks** | Endpoint reachability | HTTP, TCP, HTTPS, gRPC probes from multiple locations |
+
+> **Exam tip:** Uptime checks are the most direct answer when the requirement mentions verifying that a service is reachable from outside — they probe the endpoint from multiple global locations and trigger alerts on failure. Custom metrics let you monitor application-level signals (e.g. order count, queue depth) that are not exposed by system metrics.
+
+## Alerting
+
+| Component | Detail |
+| --- | --- |
+| **Alert policy** | Condition on a metric or log-based metric; threshold or absence trigger |
+| **Notification channels** | Email, SMS, PagerDuty, Slack, Pub/Sub, webhook |
+| **Alerting on logs** | Log-based metric → alert policy — count of matching log entries exceeding threshold |
+| **Multi-condition alerts** | Combine multiple conditions with AND/OR logic |
+
+> **Exam tip:** Alerting policies can be based on metrics (numeric thresholds) or on the absence of metric data (detects a stopped exporter). Log-based metrics let you alert on specific log patterns — for example, count of error log entries exceeding a threshold in a time window.
+
+## Cloud Logging Architecture
+
+| Component | Role |
+| --- | --- |
+| **Log sinks** | Export log entries to Cloud Storage, BigQuery, Pub/Sub |
+| **Exclusion filters** | Drop noisy log entries before ingestion billing |
+| **Log-based metrics** | Create counter or distribution metrics from log filters |
+| **Log Explorer** | Query and analyse log entries (routing, severity, resource) |
+
+> **Exam tip:** Log sinks are the answer when the requirement mentions exporting logs for long-term retention (Cloud Storage), analysis at scale (BigQuery), or streaming to a SIEM (Pub/Sub). Exclusion filters reduce ingestion cost by dropping high-volume, low-value logs before they are billed — use them for verbose debug logs in production.
+
+## Cloud Trace
+
+| Feature | Detail |
+| --- | --- |
+| **Latency distribution** | View the distribution of request latency across a service |
+| **Trace spans** | Break down latency by downstream call (HTTP, gRPC, Cloud Run, GKE) |
+| **Integration** | Auto-instrumented for Cloud Run, App Engine, GKE (with proxy); instrumented SDK for custom code |
+
+> **Exam tip:** Cloud Trace is the correct answer when the requirement mentions identifying latency bottlenecks across microservices. It does not replace application-level logging — it complements it with end-to-end latency context.
+
+## Cloud Profiler and Debugger
+
+| Service | Use Case |
+| --- | --- |
+| **Cloud Profiler** | Find where CPU or memory is being consumed in a running service; low-overhead agent, flame graph output |
+| **Cloud Debugger** | Inspect the state (variables, call stack) of a running production service at a specific point — snapshot (one-time) or logpoint (log expression without stopping) |
+
+> **Exam tip:** Cloud Profiler is chosen when the requirement mentions understanding where CPU time or memory is being spent in a production service. Cloud Debugger is chosen when the requirement mentions inspecting production state without redeploying — snapshots capture the state at a point, logpoints let you log expressions without modifying code or redeploying.

--- a/docs/google/files/networking/networking.md
+++ b/docs/google/files/networking/networking.md
@@ -1,0 +1,81 @@
+# NETWORKING
+
+## Core Networking Services
+
+| Service | Layer | Scope | Use Case | Key Feature |
+| --- | --- | --- | --- | --- |
+| **VPC** | L3 | Global (each VPC spans all regions) | Isolated virtual network, subnets per region | Global private network, firewall rules per VPC |
+| **Cloud Load Balancing** | L4/L7 | Global (HTTP/S) or regional (TCP/UDP) | Distribute traffic across backends | Global anycast IP for HTTP(S), health-checked backends |
+| **Cloud CDN** | L7 CDN | Global edge | Cache static/dynamic content close to users | Integrated with Cloud Load Balancing, cache modes |
+| **Cloud DNS** | DNS | Global | Authoritative public or private DNS | Low-latency, managed, IAM-integrated |
+| **Cloud NAT** | NAT | Regional | Outbound internet from private instances | Managed SNAT, no external IP on VM |
+| **Cloud VPN** | IPSec VPN | Regional (gateways) | Secure tunnel to on-premises | Classic VPN (route-based), HA VPN (99.99% SLA) |
+| **Cloud Interconnect** | Dedicated link | Global | Private, high-bandwidth on-prem connection | Dedicated Interconnect (colocation), Partner Interconnect |
+| **Cloud Armor** | L7 security | Global (edge) | DDoS, WAF, IP allow/block lists | Security policy attached to HTTP(S) LB |
+| **Private Service Connect** | Private access | Regional | Private access to Google APIs and services | No public internet egress for API traffic |
+
+> **Exam tip:** Cloud Load Balancing provides a single anycast IP for HTTP(S) traffic globally — choose it when the requirement mentions global HTTP load balancing with a single IP. For TCP/UDP traffic, use the regional TCP/UDP LB. Cloud CDN reduces latency and origin load for cacheable content — attach it to the HTTP(S) LB backend. For hybrid connectivity, choose Cloud VPN (modest bandwidth, no colocation) or Cloud Interconnect (high bandwidth, SLA-backed, colocation required). Private Service Connect removes the need for public internet access to Google APIs — preferred for data-exfiltration-sensitive environments.
+
+## Networking Decision Flow
+
+```mermaid
+--8<-- "google/diagrams/networking/networking-decision.mmd"
+```
+
+## VPC and Subnet Design
+
+| Concept | Detail |
+| --- | --- |
+| **VPC scope** | Global — a single VPC spans all regions; subnets are regional |
+| **Subnet mode** | Auto mode (one subnet per region, auto-created) or custom mode (full control) |
+| **IP ranges** | Primary range + secondary alias IP ranges (used for GKE pods/services) |
+| **Firewall rules** | Stateful, VPC-scoped; allow rules only (default deny ingress/egress) |
+| **Shared VPC** | Host project owns VPC; service projects attach subnets for centralised networking |
+
+> **Exam tip:** Custom mode VPC is preferred for production — it avoids surprise auto-created subnets in regions you do not use. Alias IP ranges let GKE assign pod IPs from a secondary range without NAT — critical for VPC-native clusters. Firewall rules are stateful: an allow rule for a return packet is not needed.
+
+## Load Balancer Selection
+
+| Scenario | LB Type | Scope | Protocol |
+| --- | --- | --- | --- |
+| **Global HTTP/S traffic** | Global HTTP(S) LB | Global frontend, regional backends | HTTP, HTTPS, HTTP/2, gRPC |
+| **TCP/UDP — regional** | Regional TCP/UDP LB | Regional | TCP, UDP, SSL (proxy) |
+| **Internal HTTP/S** | Internal HTTP(S) LB | Regional | HTTP, HTTPS (private VPC only) |
+| **Internal TCP/UDP** | Internal TCP/UDP LB | Regional | TCP, UDP (private VPC only) |
+| **SSL proxy** | SSL Proxy LB | Regional | SSL/TLS (non-HTTP) |
+
+> **Exam tip:** Only the global HTTP(S) LB provides a single anycast IP across all regions. Internal load balancers are for east-west traffic inside a VPC — they are not reachable from the internet. Cloud CDN can only be enabled on a global HTTP(S) LB backend.
+
+## VPC Connectivity Options
+
+| Option | Use Case | Key Feature |
+| --- | --- | --- |
+| **Cloud VPN** | Encrypted on-prem tunnel over internet | Classic VPN (single tunnel) or HA VPN (two tunnels, 99.99% SLA) |
+| **Cloud Interconnect (Dedicated)** | High-bandwidth, low-latency private link | Requires colocation at a Google peering point; SLA-backed |
+| **Cloud Interconnect (Partner)** | Private connectivity via a network service provider | No colocation — provider handles the physical link |
+| **Cloud NAT** | Outbound internet from private subnets | Managed, no external IP on instances, SNAT only |
+| **VPC Network Peering** | VPC-to-VPC private connectivity | Non-transitive; peered VPCs cannot route through each other to a third VPC |
+| **Private Service Connect** | Private access to Google APIs and managed services | No internet egress; IAM-controlled |
+
+> **Exam tip:** HA VPN is required when the requirement mentions an SLA for VPN connectivity — classic VPN has no SLA. VPC Network Peering is non-transitive: if A peers with B and B peers with C, A cannot reach C through B. For hub-and-spoke at scale, use a Shared VPC host project or a network connectivity centre.
+
+## Cloud DNS
+
+| Type | Scope | Use Case |
+| --- | --- | --- |
+| **Public zone** | Internet-facing | Public-facing domain resolution |
+| **Private zone** | VPC-scoped | Internal DNS for VPC resources; DNS peering across VPCs |
+| **Forwarding zone** | VPC-scoped | Forward queries to on-premises DNS servers via VPN/Interconnect |
+
+> **Exam tip:** Private DNS zones resolve names only from the associated VPC — they are not visible on the public internet. Use Cloud DNS peering to let one VPC resolve names from another VPC's private zone.
+
+## Cloud NAT
+
+| Scenario | Configuration |
+| --- | --- |
+| **Scale** | Cloud NAT auto-scales — no pre-provisioned capacity |
+| **Egress only** | SNAT — no inbound connections are allowed through NAT |
+| **Ports** | Ephemeral port allocation; configured per NAT IP |
+| **Logging** | Flow logs available for egress audit |
+
+> **Exam tip:** Cloud NAT lets instances without external IPs reach the internet (for updates, APIs) without a bastion. It does not allow inbound connections — use an external HTTP(S) LB or bastion for inbound access.

--- a/docs/google/files/security/security.md
+++ b/docs/google/files/security/security.md
@@ -1,0 +1,57 @@
+# SECURITY
+
+## Core Security Services
+
+| Service | Type | Best For | Key Feature |
+| --- | --- | --- | --- |
+| **Security Command Center (SCC)** | Security posture & threat detection | Asset discovery, vulnerability scanning, threat detection | Standard tier (free asset discovery, basic findings); Premium tier (Event Threat Detection, Threat Intelligence, SCC Insights) |
+| **Cloud KMS** | Key management | Encryption key lifecycle, CMEK for GCP services | Symmetric, asymmetric (RSA, EC), HMAC keys; key rotation; HSM-backed (Cloud HSM) |
+| **Secret Manager** | Secret storage | API keys, passwords, certificates, credentials | Versioning, IAM-controlled access, audit logging, OTP generation |
+| **Binary Authorization** | Container sign & verify | Enforce signed images before deployment | Signer attestations; policy per cluster; blocks unsigned or untrusted images |
+| **VPC Service Controls** | Data exfiltration perimeter | Restrict data access to a defined network perimeter | Private Google Access within perimeter; avoid public internet for data egress; supported services list |
+| **Cloud Armor** | WAF & DDoS protection | L7 security at the edge (HTTP/S LB) | WAF rules (OWASP CRS), IP allow/block lists, DDoS protection, adaptive protection |
+| **Cloud HSM** | Hardware security module | FIPS 140-2 Level 3 key storage | Dedicated HSM partition; integration with Cloud KMS |
+|| **Cloud IAM** | Access control | Identity-based permissions | Covered in [Identity & Access](../identity/identity.md) |
+
+> **Exam tip:** Security Command Center is the central security and risk management platform — Standard tier covers asset discovery and basic vulnerability findings. Premium tier adds Event Threat Detection (suspicious activity in logs), Threat Intelligence (known-bad indicators), and SCC Insights (identity and data risk analysis). Cloud Armor attaches to the HTTP(S) Load Balancer for WAF and IP-based protection at the edge. VPC Service Controls create a security perimeter around projects — data cannot leave the perimeter via supported services over the public internet.
+
+## Security Command Center Tiers
+
+| Tier | Covers | Key Feature |
+| --- | --- | --- |
+| **Standard** | Asset discovery, basic security findings, fundamential vulnerability scanning | Always on; no cost for the core tier (there may be charges for optional services) |
+| **Premium** | All Standard features + Event Threat Detection, Threat Intelligence, SCC Insights | Advanced threat detection using built-in analytics on log data; threat intel feeds |
+
+> **Exam tip:** Choose SCC Standard for continuous asset inventory and basic vulnerability/discovery findings. Choose SCC Premium when the requirement mentions threat detection from log-based analytics, threat intelligence feeds, or identity and data risk analysis.
+
+## Encryption Options
+
+| Mechanism | Scope | Key Owned By |
+| --- | --- | --- |
+| **Google-managed encryption (GMEK)** | Default for all GCP services | Google — lowest overhead |
+| **Customer-managed encryption keys (CMEK)** | Storage, SQL, BigQuery, etc. | Customer in Cloud KMS — auditable, rotatable |
+| **Customer-supplied encryption keys (CSEK)** | Cloud Storage only | Customer provides key per request — not persisted by Google |
+| **Cloud HSM** | FIPS 140-2 Level 3 HSMs | Customer controls the HSM partition |
+
+> **Exam tip:** CMEK is the most common compliance answer — you retain control of the key in Cloud KMS, with full audit logging and automatic rotation. CSEK is rarely chosen because Google does not store the key — every request must supply the key, which adds operational burden. Cloud HSM satisfies requirements that mandate a FIPS 140-2 Level 3 hardware boundary for key material.
+
+## Binary Authorization
+
+| Policy | Behaviour |
+| --- | --- |
+| **Require signature by attested signer** | Container image must be signed by a designated signer before deployment to a cluster |
+| **Attestors** | Verify that an image was signed by a trusted authority (e.g. CI/CD pipeline) |
+| **Cluster-level enforcement** | Policy is applied per GKE cluster; unsigned images are blocked at deploy time |
+
+> **Exam tip:** Binary Authorization is the answer when the requirement mentions supply-chain security for containers — ensuring only images built and signed by an approved pipeline can be deployed. It protects against unauthorised or tampered images reaching production GKE clusters.
+
+## VPC Service Controls
+
+| Feature | Detail |
+| --- | --- |
+| **Security perimeter** | Groups projects and services into a boundary; data cannot leave via supported services over the public internet |
+| **Private Google Access** | Within the perimeter, instances without external IPs can reach Google APIs privately |
+| **Supported services** | Cloud Storage, BigQuery, Bigtable, Cloud SQL, Pub/Sub, and others (growing list) |
+| **Access levels** | Can restrict access to resources within the perimeter based on context (IP, device attributes) |
+
+> **Exam tip:** VPC Service Controls are the answer when the requirement mentions preventing data exfiltration over the public internet for sensitive data workloads. VPC-SC does not replace firewall rules or IAM — it operates at the service perimeter layer, blocking data egress paths that IAM alone cannot control.

--- a/docs/google/files/storage/storage.md
+++ b/docs/google/files/storage/storage.md
@@ -1,0 +1,65 @@
+# STORAGE
+
+## Cloud Storage Classes
+
+| Class | Use Case | Min Retention | Retrieval Latency |
+| --- | --- | --- | --- |
+| **Standard** | Frequently accessed, hot data | None | Milliseconds |
+| **Nearline** | Infrequent access — backup, monthly access | 30 days | Milliseconds |
+| **Coldline** | Rare access — quarterly backup, disaster recovery | 90 days | Milliseconds |
+| **Archive** | Long-term retention, compliance | 365 days | Hours (rehydration required) |
+
+> **Exam tip:** Choose Standard for active data. Choose Nearline for data accessed once a month. Choose Coldline for data accessed once a quarter. Choose Archive for data that must be retained for years and rarely accessed. Accessing data before the minimum retention period incurs an early deletion charge.
+
+## Cloud Storage vs Persistent Disk vs Filestore
+
+| Service | Protocol/Type | Scope | Best For |
+| --- | --- | --- | --- |
+| **Cloud Storage** | Object (REST/HTTP) | Regional, dual-region, or multi-region | Unstructured data, backups, data lake, static hosting |
+| **Persistent Disk** | Block (attached to VM) | Regional or zonal | VM boot and data disks, databases |
+| **Filestore** | File (NFS v3/4.1) | Regional | Lift-and-shift file shares, shared config |
+
+> **Exam tip:** Cloud Storage is object storage — it does not provide a filesystem interface to VMs. Persistent Disk is block storage — attachable to Compute Engine VMs as a mounted disk. Filestore is NFS — mountable by multiple VMs simultaneously. For shared read/write file access across many VMs, use Filestore. For durable VM-attached disks, use Persistent Disk. For unstructured object data, use Cloud Storage.
+
+## Relational Database Options
+
+| Service | Type | Best For | Key Feature |
+| --- | --- | --- | --- |
+| **Cloud SQL** | Managed relational (MySQL, PostgreSQL, SQL Server) | Regional OLTP workloads | Managed backups, replication, high availability (HA) configuration |
+| **AlloyDB** | PostgreSQL-compatible, high-performance | Analytical and high-throughput OLTP | Columnar storage for analytics, low-latency transactional processing |
+| **Cloud Spanner** | Globally distributed, horizontally scalable relational | Global OLTP with strong consistency | Synchronous replication across regions, SQL queries, automatic sharding |
+
+> **Exam tip:** Choose Cloud SQL when you need a managed PostgreSQL/MySQL instance in a single region with familiar tooling. Choose AlloyDB when you need PostgreSQL compatibility with integrated analytical query performance over the same data. Choose Spanner when the requirement mentions global scale, strong consistency across regions, or horizontal write scaling — Spanner is the only option that provides globally synchronous replication with SQL semantics.
+
+## NoSQL Options
+
+| Service | Type | Best For | Key Feature |
+| --- | --- | --- | --- |
+| **Cloud Bigtable** | Wide-column NoSQL | High-throughput, low-latency key-value and time-series | Single-digit-millisecond latency, scales to billions of rows |
+| **Firestore** | Document NoSQL | Mobile/web app backend, real-time sync | Offline persistence, real-time listeners, automatic scaling |
+
+> **Exam tip:** Choose Bigtable for large-scale time-series, IoT, or analytics workloads where low-latency key access is critical — it is not a general-purpose document store. Choose Firestore when the workload is a web or mobile application requiring real-time document sync and offline support. Bigtable does not support secondary indexes or complex queries; Firestore supports limited querying with single-field indexes and composite indexes you create explicitly.
+
+## Analytics Data Warehouse
+
+| Service | Type | Best For | Key Feature |
+| --- | --- | --- | --- |
+| **BigQuery** | Serverless data warehouse | SQL analytics over petabytes | On-demand pricing or flat-rate slots, separation of compute and storage, BI Engine for low-latency |
+
+> **Exam tip:** BigQuery is the answer for any requirement that mentions SQL analytics at scale without infrastructure management. For streaming inserts, use BigQuery streaming API or load from Cloud Storage, Pub/Sub, or Dataflow. BigQuery Omni allows querying data stored in AWS S3 or Azure Blob Storage from BigQuery.
+
+## Storage Decision Flow
+
+```mermaid
+--8<-- "google/diagrams/storage/storage-decision.mmd"
+```
+
+## Cloud Storage Replication
+
+| Replication | Scope | Use Case |
+| --- | --- | --- |
+| **Regional** | Single region, multiple zones | Same-region durability, lowest cost |
+| **Dual-region** | Two regions in same continent | Low-latency multi-region access within a continent |
+| **Multi-region** | Three or more regions globally | Highest availability, global read access |
+
+> **Exam tip:** Multi-region Cloud Storage provides the highest durability (11 9s) but at higher cost and with eventual consistency for overwrites across regions. For strong consistency within a single region, choose regional storage.

--- a/docs/google/files/waf/waf.md
+++ b/docs/google/files/waf/waf.md
@@ -1,0 +1,89 @@
+# Well-Architected Framework
+
+> **Exam Focus:** Use WAF pillars to *justify* design decisions in
+> case-study questions — not just to name the correct service.
+> Relevant for **Professional Cloud Architect** and **Professional DevOps Engineer**.
+
+## Six Pillars Overview
+
+| Pillar | Goal | Key GCP Services / Patterns | Exam Focus |
+| --- | --- | --- | --- |
+| **Operational Excellence** | Run and monitor systems to deliver business value | Cloud Build, Cloud Deploy, Cloud Logging, Cloud Monitoring, Cloud Trace, Cloud Debugger, Error Reporting | CI/CD pipelines, observability strategy, SRE practices |
+| **Security** | Protect data, identities, and workloads | Cloud IAM, Cloud KMS, Secret Manager, SCC, VPC Service Controls, Binary Authorization, Cloud Armor | Zero Trust (Beyond Corp), defence-in-depth, data exfiltration prevention |
+| **Reliability** | Recover from failures and meet demand | Multi-zone/region architectures, Cloud Load Balancing, Cloud SQL HA, Cloud Spanner, Backup and DR | RTO/RPO targets, region vs zone failure, backup strategies |
+| **Performance Efficiency** | Use resources efficiently as demand changes | Cloud Run autoscaling, GKE autoscaling (HPA/Cluster Autoscaler), Cloud CDN, Persistent Disk types, machine families | Right-sizing, caching, autoscaling, choosing the right storage class |
+| **Cost Optimization** | Maximise value; eliminate waste | Commited Use Discounts, Sustained Use Discounts, Preemptible/Spot VMs, Budget alerts, Cloud Monitoring cost metrics, right-sizing | Commitment vs on-demand trade-offs, storage class selection, idle resource elimination |
+| **Sustainability** | Minimise environmental impact | Carbon footprint tracking, efficient regions, right-sizing | Region carbon intensity, resource efficiency, waste reduction |
+
+> **Cross-reference:** See [High Availability & Disaster Recovery](../ha-dr/ha-dr.md) for Reliability patterns, [Security](../security/security.md) for defence-in-depth, [Networking — CDN](../networking/networking.md) for Cloud CDN/Front Door, [Compute](../compute/compute.md) for autoscaling and machine family selection, [Governance](../governance/governance.md) for cost control tooling.
+
+## Reliability — SLA Target Mapping
+
+| SLA Target | Recommended Deployment Pattern | Notes |
+| --- | --- | --- |
+| **99.9%** | Single region, multi-zone | Survives a single zone failure; appropriate for non-critical workloads |
+| **99.99%** | Multi-zone or multi-region depending on service | Cloud SQL HA, regional Persistent Disk, multi-zone GKE node pools |
+| **99.999%** | Multi-region active-active | Cloud Spanner multi-region, Cloud Storage multi-region, global HTTP(S) LB with multi-region backends |
+
+> **Exam tip:** A single zone failure is survivable with regional redundancy (multi-zone). A full region failure requires multi-region deployment. Know which services support which redundancy modes — for example, Cloud SQL HA is regional only; Cloud Spanner multi-region is the option for global strong consistency.
+
+## Cost Optimization — Pricing Model Selection
+
+| Option | Best For | Commitment | Risk |
+| --- | --- | --- | --- |
+| **On-demand** | Unpredictable workloads, short-term dev/test | None | None |
+| **Committed Use Discounts (CUDs)** | Steady-state, 24/7 production workloads | 1 or 3 years | None (capacity not reserved, only discount committed) |
+| **Sustained Use Discounts** | Automatic discount for VMs running most of the month | None (automatic) | None |
+| **Spot/Preemptible VMs** | Fault-tolerant batch jobs, HPC, dev/test | None | Yes (preemption after 24h max, or earlier) |
+| **Savings Plans (Compute Engine)** | Commitment to spend amount rather than specific VMs | 1 or 3 years | None (flexible across instance families and regions) |
+
+> **Exam tip:** Committed Use Discounts provide a discount for committed usage without reserving specific capacity — choose them for steady-state production workloads where the VM family and region are predictable. Sustained Use Discounts apply automatically when a VM runs most of the month — they are not a separate purchase. Spot/Preemptible VMs are the cheapest but can be terminated at any time — use only for fault-tolerant workloads.
+
+## Security Pillar — Defence-in-Depth Summary
+
+| Layer | GCP Control |
+| --- | --- |
+| **Identity** | Cloud IAM (least privilege), MFA, IAP, workload identity |
+| **Data** | CMEK (Cloud KMS), Secret Manager, VPC Service Controls, encryption at rest/transit |
+| **Network** | VPC firewall rules, Cloud NAT, Private Google Access, Cloud Armor, VPC Service Controls perimeter |
+| **Workload** | Binary Authorization, Container Analysis, SCC vulnerability scanning, secure boot |
+| **Monitoring** | Cloud Logging, Cloud Monitoring, SCC (Standard and Premium), audit logs |
+
+> **Exam tip:** Defence-in-depth means applying controls at every layer — identity, data, network, workload, monitoring. A single control (e.g. IAM) is not enough for a production security posture. VPC Service Controls add a data exfiltration layer that IAM alone cannot provide.
+
+## Operational Excellence — CI/CD and Observability
+
+| Capability | GCP Service |
+| --- | --- |
+| **CI/CD** | Cloud Build (CI), Cloud Deploy (CD to GKE, Cloud Run, Anthos), Artifact Registry |
+| **Infrastructure as Code** | Terraform, Deployment Manager (legacy), Config Connector |
+| **Logging** | Cloud Logging — centralised log aggregation, sinks, exclusion |
+| **Metrics and alerting** | Cloud Monitoring — metrics, dashboards, uptime checks, alert policies |
+| **Tracing** | Cloud Trace — distributed latency analysis |
+| **Profiling** | Cloud Profiler — CPU and memory profiling of production services |
+| **Debugging** | Cloud Debugger — inspect production state without redeploy |
+| **Error reporting** | Error Reporting — aggregates and groups errors from Cloud Logging |
+
+> **Exam tip:** Cloud Build is the CI service; Cloud Deploy is the CD service for GKE, Cloud Run, and Anthos. Cloud Deploy uses Skaffold under the hood for GKE deployments. For observability, Cloud Logging and Cloud Monitoring are the foundational services; Cloud Trace, Profiler, Debugger, and Error Reporting are the specialised tooling on top.
+
+## Performance Efficiency — Autoscaling
+
+| Service | Autoscaling Mechanism |
+| --- | --- |
+| **Cloud Run** | Scale-to-zero and per-request scaling; concurrency configurable |
+| **GKE** | Horizontal Pod Autoscaler (HPA), Vertical Pod Autoscaler (VPA), Cluster Autoscaler, Node Auto-Provisioning |
+| **Compute Engine** | Managed instance group autoscaling based on CPU, loadBalancer, custom metrics |
+| **App Engine** | Automatic scaling (standard) or manual / basic scaling |
+
+> **Exam tip:** Cloud Run provides the simplest autoscaling model — scale to zero when idle, scale out per request. GKE provides the most flexible autoscaling (HPA, VPA, Cluster Autoscaler, node auto-provisioning) but also the most operational complexity. For predictable, always-on capacity, Managed Instance Groups with autoscaling based on CPU or load balancer capacity is the choice.
+
+## Sustainability
+
+| Practice | GCP Feature |
+| --- | --- |
+| **Carbon footprint tracking** | Carbon Footprint report in Cloud Console — shows emissions by project/region |
+| **Region selection** | Choose regions with lower carbon intensity |
+| **Right-sizing** | Use right-sizing recommendations to reduce idle or over-provisioned resources |
+| **Efficient machine types** | E2 instances (shared-core), C2D (AMD Eco), Spot/Preemptible for batch workloads |
+
+> **Exam tip:** Sustainability is part of the Google Cloud Well-Architected Framework. Key practices are choosing low-carbon regions, right-sizing resources, using efficient machine types (E2, C2D), and using preemptible/spot VMs for batch workloads where the preemption risk is acceptable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,21 +35,40 @@ See the [Azure Exam Track Index](azure/files/exams/exams.md) for full coverage b
 
 Organised by domain. Each section covers service selection and architectural trade-offs.
 
-| Domain | Content |
-|--------|---------|
-| [Compute](aws/files/compute/compute.md) | EC2, Lambda, ECS, EKS, Elastic Beanstalk |
-| [Networking](aws/files/networking/networking.md) | VPC, Route 53, CloudFront, ELB, API Gateway |
-| [Storage](aws/files/storage/storage.md) | S3, EBS, EFS, Glacier, Storage Gateway |
-| [Identity & Access](aws/files/identity/identity.md) | IAM, Organizations, SSO, Cognito |
-| [Security](aws/files/security/security.md) | GuardDuty, Security Hub, WAF, Shield, KMS |
-| [Database](aws/files/database/database.md) | RDS, Aurora, DynamoDB, ElastiCache, Redshift |
-| [Monitoring & Observability](aws/files/monitoring/monitoring.md) | CloudWatch, CloudTrail, X-Ray, Config |
-| [Messaging & Integration](aws/files/messaging/messaging.md) | SQS, SNS, EventBridge, Step Functions |
-| [Governance](aws/files/governance/governance.md) | Organizations, SCPs, Control Tower, Budgets |
-| [High Availability & DR](aws/files/ha-dr/ha-dr.md) | Multi-AZ, Multi-Region, AWS Backup, Route 53 |
-| [Well-Architected Framework](aws/files/waf/waf.md) | Six pillars, trade-off navigator |
+|| Domain | Content |
+||--------|---------|
+|| [Compute](aws/files/compute/compute.md) | EC2, Lambda, ECS, EKS, Elastic Beanstalk |
+|| [Networking](aws/files/networking/networking.md) | VPC, Route 53, CloudFront, ELB, API Gateway |
+|| [Storage](aws/files/storage/storage.md) | S3, EBS, EFS, Glacier, Storage Gateway |
+|| [Identity & Access](aws/files/identity/identity.md) | IAM, Organizations, SSO, Cognito |
+|| [Security](aws/files/security/security.md) | GuardDuty, Security Hub, WAF, Shield, KMS |
+|| [Database](aws/files/database/database.md) | RDS, Aurora, DynamoDB, ElastiCache, Redshift |
+|| [Monitoring & Observability](aws/files/monitoring/monitoring.md) | CloudWatch, CloudTrail, X-Ray, Config |
+|| [Messaging & Integration](aws/files/messaging/messaging.md) | SQS, SNS, EventBridge, Step Functions |
+|| [Governance](aws/files/governance/governance.md) | Organizations, SCPs, Control Tower, Budgets |
+|| [High Availability & DR](aws/files/ha-dr/ha-dr.md) | Multi-AZ, Multi-Region, AWS Backup, Route 53 |
+|| [Well-Architected Framework](aws/files/waf/waf.md) | Six pillars, trade-off navigator |
 
 See the [AWS Exam Track Index](aws/files/exams/exams.md) for full coverage by certification.
+
+### Google Cloud
+
+Organised by domain. Each section covers service selection and architectural trade-offs.
+
+|| Domain | Content |
+||--------|---------|
+|| [Compute](google/files/compute/compute.md) | Compute Engine, GKE, Cloud Run, Cloud Functions, App Engine |
+|| [Networking](google/files/networking/networking.md) | VPC, Cloud Load Balancing, Cloud CDN, Cloud DNS, Cloud NAT, Cloud Armor |
+|| [Storage](google/files/storage/storage.md) | Cloud Storage, Persistent Disk, Filestore, Bigtable, Spanner, Firestore, BigQuery |
+|| [Identity & Access](google/files/identity/identity.md) | Cloud IAM, Cloud Identity, Workload Identity, Service Accounts, IAP |
+|| [Security](google/files/security/security.md) | SCC, Secret Manager, Cloud KMS, Binary Authorization, VPC Service Controls, Cloud Armor |
+|| [Monitoring & Observability](google/files/monitoring/monitoring.md) | Cloud Monitoring, Cloud Logging, Cloud Trace, Cloud Profiler, Cloud Debugger |
+|| [Messaging & Integration](google/files/messaging/messaging.md) | Pub/Sub, Eventarc, Workflows, Cloud Tasks, API Gateway |
+|| [Governance](google/files/governance/governance.md) | Organization Policy, Resource Manager, Cloud Asset Inventory, Billing Budgets, Policy Troubleshooter |
+|| [High Availability & DR](google/files/ha-dr/ha-dr.md) | Regional vs multi-regional, Cloud DNS failover, Cloud Load Balancing global failover, Backup for GCE, Spanner replication |
+|| [Well-Architected Framework](google/files/waf/waf.md) | Six pillars, trade-off navigator |
+
+See the [Google Cloud Exam Track Index](google/files/exams/exams.md) for full coverage by certification.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,3 +89,16 @@ nav:
         - Governance: azure/files/governance/governance.md
         - Messaging & Integration: azure/files/messaging/messaging.md
         - Well-Architected Framework: azure/files/waf/waf.md
+    - Google Cloud:
+        - Abbreviations: google/files/abbreviations/abbreviations.md
+        - Exam Coverage: google/files/exams/exams.md
+        - Compute: google/files/compute/compute.md
+        - Networking: google/files/networking/networking.md
+        - Storage: google/files/storage/storage.md
+        - Identity & Access: google/files/identity/identity.md
+        - Security: google/files/security/security.md
+        - Monitoring & Observability: google/files/monitoring/monitoring.md
+        - Messaging & Integration: google/files/messaging/messaging.md
+        - Governance: google/files/governance/governance.md
+        - High Availability & DR: google/files/ha-dr/ha-dr.md
+        - Well-Architected Framework: google/files/waf/waf.md


### PR DESCRIPTION
## Summary
Resolves #239 — FEATURE: Add Google Cloud Cheat Sheets
## Changes
- The site navigation under `Cloud Service Providers` only lists AWS and Azure. There is no Google Cloud section, so even if Google Cloud content existed it would not be reachable from the site.
- The home page lists only Microsoft Azure and Amazon Web Services under `Cloud Service Providers`. Google Cloud is not discoverable from the site landing page.
- The `Current Content` table on line 16-17 lists only Microsoft Azure and Amazon Web Services. The `Repository Structure` section on line 26-36 uses `docs/azure/...` as the only concrete provider example and does not mention Google Cloud.
- No Google Cloud domain pages exist. Each domain page must be comparison-oriented with service-selection tables, decision guidance, and exam-tip callouts, consistent with existing Azure and AWS pages.
- No standalone Mermaid diagram sources exist for Google Cloud. Existing convention stores one `.mmd` file per diagram under `docs/<provider>/diagrams/<section>/<slug>.mmd`.
- New Google Cloud nav entries must resolve to real files that exist, otherwise `make docs-build` (strict) will fail. The nav structure must match the actual file tree.

**Tasks:**
- Create `docs/google/files/` directory tree with sub-directories for each domain: abbreviations, exams, compute, networking, storage, identity, security, monitoring, messaging, governance, ha-dr, waf
- Create `docs/google/diagrams/` directory tree with sub-directories per domain for standalone `.mmd` files
- Add Google Cloud section to `mkdocs.yml` under `Cloud Service Providers` with nav entries for each domain page (abbreviations, exams, compute, networking, storage, identity, security, monitoring, messaging, governance, ha-dr, waf)
- Add Google Cloud section to `docs/index.md` after AWS, with a domain table linking to each Google Cloud page
- Add Google Cloud to the `Current Content` table in `README.md`
- Update `README.md` `Repository Structure` code block to include `docs/google/` alongside `docs/azure/` and `docs/aws/`
- Write `docs/google/files/abbreviations/abbreviations.md` — Google Cloud service acronyms and abbreviations reference
- Write `docs/google/files/exams/exams.md` — Google Cloud certification exam track overview and coverage matrix
- Write `docs/google/files/compute/compute.md` — Compute Engine, GKE, Cloud Run, Cloud Functions, App Engine comparison table with decision guidance
- Write `docs/google/files/networking/networking.md` — VPC, Cloud Load Balancing, Cloud CDNs, Cloud DNS, Cloud NAT, Network Security comparison table with decision guidance
- Write `docs/google/files/storage/storage.md` — Cloud Storage, Persistent Disk, Filestore, Bigtable, Spanner, Firestore, BigQuery comparison table with decision guidance
- Write `docs/google/files/identity/identity.md` — Cloud IAM, Cloud Identity, workload identity, service accounts comparison table with decision guidance
- Write `docs/google/files/security/security.md` — Security Command Center, Secret Manager, KMS, Binary Authorization, VPC Service Controls comparison table with decision guidance
- Write `docs/google/files/monitoring/monitoring.md` — Cloud Monitoring, Cloud Logging, Cloud Trace, Cloud Profiler, Cloud Debugger comparison table with decision guidance
- Write `docs/google/files/messaging/messaging.md` — Pub/Sub, Eventarc, Workflows, Cloud Tasks, Eventarc comparison table with decision guidance
- Write `docs/google/files/governance/governance.md` — Organization Policy, Resource Manager, Cloud Asset Inventory, Billing budgets, Policy Troubleshooter comparison table with decision guidance
- Write `docs/google/files/ha-dr/ha-dr.md` — Regional vs multi-regional, Cloud DNS failover, Cloud Load Balancing global failover, Backup for GCE, Spanner replication comparison table with decision guidance
- Write `docs/google/files/waf/waf.md` — Google Cloud architecture framework pillars and trade-off guidance
- Create `docs/google/diagrams/compute/compute-decision.mmd` — decision flow for choosing between Compute Engine, GKE, Cloud Run, Cloud Functions, and App Engine
- Create `docs/google/diagrams/networking/networking-decision.mmd` — decision flow for choosing load balancing, CDN, and network connectivity options
## Testing
Run the full test suite — all tests must pass.
Closes #239