### PR TITLE
fix: resolve #223 - BUG: Fix path-traversal vulnerability: add is_relative_to gu

### DIFF
--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -90,6 +90,8 @@ def _expand_snippet(block_src: str, base_dir: Path) -> str | None:
         return None
     rel_path = m.group(1)
     abs_path = (base_dir / rel_path).resolve()
+    if not abs_path.is_relative_to(base_dir.resolve()):
+        raise RuntimeError(f"Snippet path escapes base directory: {abs_path}")
     try:
         return abs_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
@@ -115,6 +117,8 @@ def _expand_top_level_snippets(content: str, base: Path) -> str:
     def _replace(m: re.Match) -> str:
         rel = m.group(1)
         abs_path = (base / rel).resolve()
+        if not abs_path.is_relative_to(base.resolve()):
+            return m.group(0)  # reject path traversal outside base
         try:
             return abs_path.read_text(encoding="utf-8")
         except OSError:

--- a/tests/test_mermaid_validation.py
+++ b/tests/test_mermaid_validation.py
@@ -555,6 +555,24 @@ class TestExpandTopLevelSnippetsOSError:
         assert result == directive
 
 
+class TestExpandSnippetRejectsTraversal:
+    """Covers issue #223: _expand_snippet rejects path-traversal directives."""
+
+    def test_rejects_traversal(self, tmp_path):
+        block = '--8<-- "../../../../etc/passwd"'
+        with pytest.raises(RuntimeError, match="escapes base directory"):
+            validate_mermaid._expand_snippet(block, tmp_path)
+
+
+class TestExpandTopLevelSnippetsRejectsTraversal:
+    """Covers issue #223: _expand_top_level_snippets leaves traversal directives unexpanded."""
+
+    def test_rejects_traversal(self, tmp_path):
+        directive = '--8<-- "../../../../etc/passwd"'
+        result = validate_mermaid._expand_top_level_snippets(directive, tmp_path)
+        assert result == directive
+
+
 class TestExtractMermaidBlocksNoExpand:
     """Covers line 158: early return when expand_snippets=False."""
 


### PR DESCRIPTION
## Summary

Resolves #223 — Adds `is_relative_to` guards to `_expand_snippet` and `_expand_top_level_snippets` in `validate_mermaid.py` to prevent path-traversal attacks via crafted `--8<--` directives that could read arbitrary host files.

## Changes

- **scripts/validate_mermaid.py**: Added `is_relative_to` boundary check after resolving `abs_path` in `_expand_snippet` (raises `RuntimeError` on traversal) and in `_expand_top_level_snippets._replace` (returns directive unchanged on traversal), matching the guard already proven in `tests/conftest.py`
- **tests/test_mermaid_validation.py**: Added `TestExpandSnippetRejectsTraversal` and `TestExpandTopLevelSnippetsRejectsTraversal` regression test classes covering the `--8<-- "../../../../etc/passwd"` attack vector

## Testing

- `pytest tests/test_mermaid_validation.py::TestExpandSnippetRejectsTraversal tests/test_mermaid_validation.py::TestExpandTopLevelSnippetsRejectsTraversal -v` — both new test classes pass
- `make ci` — full pipeline passes clean

## Closes #223