### PR TITLE
fix: resolve #197 - BUG: Add validate_mermaid.py test for validate_block() when 

### DIFF
--- a/scripts/validate_mermaid.py
+++ b/scripts/validate_mermaid.py
@@ -210,7 +210,7 @@ def validate_block(index, diagram_src, timeout: int | None = None):
                     "mmdc produced an empty/degenerate SVG (possible silent render failure)",
                 )
             return True, result.stderr
-        return False, result.stderr
+        return False, result.stderr or result.stdout
     except subprocess.TimeoutExpired:
         return (False, f"mmdc timed out after {timeout} s")
     except FileNotFoundError:

--- a/tests/test_mermaid_validation.py
+++ b/tests/test_mermaid_validation.py
@@ -640,7 +640,10 @@ class TestValidateBlockStderrEmptyStdoutPresent:
         with (
             patch("validate_mermaid.PUPPETEER_CONFIG") as mock_cfg,
             patch("validate_mermaid.subprocess.run", return_value=mock_result),
-            patch("validate_mermaid.extract_mermaid_blocks", return_value=["graph TD\n  A --> B\n"]),
+            patch(
+                "validate_mermaid.extract_mermaid_blocks",
+                return_value=["graph TD\n  A --> B\n"],
+            ),
             patch("validate_mermaid.Path.is_file", return_value=True),
         ):
             mock_cfg.exists.return_value = False

--- a/tests/test_mermaid_validation.py
+++ b/tests/test_mermaid_validation.py
@@ -613,6 +613,43 @@ class TestValidateBlockNonZeroReturnCode:
         assert "syntax error" in err
 
 
+class TestValidateBlockStderrEmptyStdoutPresent:
+    """Covers line 213 when mmdc exits non-zero with empty stderr but stdout has content."""
+
+    def test_returns_stdout_when_stderr_is_empty(self):
+        import subprocess
+
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="parse error: unexpected token", stderr=""
+        )
+        with (
+            patch("validate_mermaid.PUPPETEER_CONFIG") as mock_cfg,
+            patch("validate_mermaid.subprocess.run", return_value=mock_result),
+        ):
+            mock_cfg.exists.return_value = False
+            ok, err = validate_mermaid.validate_block(1, "graph TD\n  A --> B\n")
+        assert ok is False
+        assert err == "parse error: unexpected token"
+
+    def test_stderr_empty_stdout_present_is_printed_by_run(self, capsys):
+        import subprocess
+
+        mock_result = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="syntax error", stderr=""
+        )
+        with (
+            patch("validate_mermaid.PUPPETEER_CONFIG") as mock_cfg,
+            patch("validate_mermaid.subprocess.run", return_value=mock_result),
+            patch("validate_mermaid.extract_mermaid_blocks", return_value=["graph TD\n  A --> B\n"]),
+            patch("validate_mermaid.Path.is_file", return_value=True),
+        ):
+            mock_cfg.exists.return_value = False
+            validate_mermaid.run(["docs/test.md"])
+        captured = capsys.readouterr()
+        assert "syntax error" in captured.out
+        assert "Diagram 1: FAIL" in captured.out
+
+
 class TestValidateMmdFile:
     """Covers lines 207-228: _validate_mmd_file."""
 


### PR DESCRIPTION
## Summary

Resolves #197 — Adds a test for `validate_block()` when `mmdc` exits non-zero with empty stderr and fixes the function to return stdout content as the error message in that case, so CI operators get diagnostic information instead of a blank message.

## Changes

- **scripts/validate_mermaid.py**: Changed `return False, result.stderr` to `return False, result.stderr or result.stdout` so that when `mmdc` emits parse errors to stdout rather than stderr, the error message is still surfaced to callers and the output loops in `run()` and `_validate_mmd_file()`.
- **tests/test_mermaid_validation.py**: Added `TestValidateBlockStderrEmptyStdoutPresent` class with two tests: one asserting `validate_block()` returns the stdout content when stderr is empty, and one asserting that `run()` prints the stdout error to captured output.

## Testing

- `pytest tests/test_mermaid_validation.py::TestValidateBlockStderrEmptyStdoutPresent -v` — runs the new tests
- `pytest tests/ -v --cov=scripts --cov-fail-under=90` — verifies all existing tests pass and coverage threshold is met
- `ruff check scripts/` — lint check passes

## Closes #197