### PR TITLE
fix: resolve #127 - FEATURE: Add CONTRIBUTING.md entry for Mermaid diagram autho

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ clean, reviewable contributions to this repository.
     - [Python Scripts](#python-scripts)
     - [Section Snippet Files](#section-snippet-files)
     - [Diagram Files](#diagram-files)
+    - [Mermaid Diagrams](#mermaid-diagrams)
   - [10. Deprecation warnings](#10-deprecation-warnings)
   - [11. Dependabot update strategy](#11-dependabot-update-strategy)
 
@@ -334,7 +335,37 @@ Rules:
   `ha-dr`, `governance`, `messaging`, `waf`.
 - To reuse a diagram in a second cheat sheet, reference the same `.mmd` file from
   the shared section snippet. The `.mmd` source is the single source of truth.
-- Run `make mermaid-check` after adding or editing any `.mmd` file.
+- Run `make mermaid-check` after adding or editing any `.mmd` file`.
+
+### Mermaid Diagrams
+
+#### Directive selection
+
+Choose the Mermaid directive based on the diagram's purpose:
+
+| Purpose                    | Directive       |
+|----------------------------|-----------------|
+| Decision flows (if/else)   | `flowchart TD`  |
+| Hierarchy / ecosystem maps | `graph TD`      |
+| Connectivity / network     | `graph LR`      |
+
+#### Heading convention
+
+When a diagram illustrates a decision flow, place the heading `### Decision Flow`
+immediately after the relevant table. This keeps the diagram visually anchored to
+the decision it supports.
+
+#### Local validation
+
+Before opening a PR, validate your diagram locally:
+
+```bash
+python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md
+```
+
+This runs the same `mmdc` rendering check that `make mermaid-check` uses, but
+targets a single file. Use it when you want fast feedback on one diagram without
+waiting for the full Mermaid check to run across all files.
 
 ---
 

--- a/docs/azure/files/storage/storage.md
+++ b/docs/azure/files/storage/storage.md
@@ -285,7 +285,7 @@ sas_token = generate_blob_sas(
     account_name=ACCOUNT_NAME,
     container_name="mycontainer",
     blob_name="report.pdf",
-    account_key=ACCOUNT_KEY,          # omit and pass user_delegation_key for User Delegation SAS
+    account_key=ACCOUNT_KEY,  # omit and pass user_delegation_key for User Delegation SAS
     permission=BlobSasPermissions(read=True),
     expiry=datetime.now(timezone.utc) + timedelta(hours=1),
 )

--- a/tests/test_issue_127.py
+++ b/tests/test_issue_127.py
@@ -1,0 +1,70 @@
+"""Tests for issue #127 — FEATURE: Add CONTRIBUTING.md entry for Mermaid diagram authoring conventions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from conftest import REPO_ROOT
+
+CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+
+
+class TestContributingMermaidDiagramsSubsection:
+    """Verify the new Mermaid Diagrams subsection added to §9 of CONTRIBUTING.md."""
+
+    def _contributing_text(self) -> str:
+        return CONTRIBUTING.read_text(encoding="utf-8")
+
+    def test_mermaid_diagrams_subsection_heading_present(self) -> None:
+        text = self._contributing_text()
+        assert "### Mermaid Diagrams" in text, (
+            "CONTRIBUTING.md missing '### Mermaid Diagrams' subsection heading"
+        )
+
+    def test_directive_selection_table_present(self) -> None:
+        text = self._contributing_text()
+        assert "| Purpose                    | Directive       |" in text, (
+            "CONTRIBUTING.md missing directive-selection table header"
+        )
+        assert "| Decision flows (if/else)   | `flowchart TD`  |" in text, (
+            "CONTRIBUTING.md missing flowchart TD row"
+        )
+        assert "| Hierarchy / ecosystem maps | `graph TD`      |" in text, (
+            "CONTRIBUTING.md missing graph TD row"
+        )
+        assert "| Connectivity / network     | `graph LR`      |" in text, (
+            "CONTRIBUTING.md missing graph LR row"
+        )
+
+    def test_heading_convention_documented(self) -> None:
+        text = self._contributing_text()
+        assert "### Decision Flow" in text, (
+            "CONTRIBUTING.md missing heading convention (### Decision Flow)"
+        )
+        assert "immediately after the relevant table" in text, (
+            "CONTRIBUTING.md missing heading placement guidance"
+        )
+
+    def test_local_validation_command_documented(self) -> None:
+        text = self._contributing_text()
+        assert "python3 scripts/validate_mermaid.py docs/AZ-305_CheatSheet.md" in text, (
+            "CONTRIBUTING.md missing per-file validation command"
+        )
+
+    def test_mermaid_diagrams_subsection_is_in_section_9(self) -> None:
+        """The new subsection must appear before the --- separator that ends §9 (before §10)."""
+        text = self._contributing_text()
+        section_9_mermaid_idx = text.find("### Mermaid Diagrams")
+        section_separator_idx = text.find("\n---\n\n## 10. Deprecation")
+        assert section_9_mermaid_idx > 0, "Mermaid Diagrams subsection not found"
+        assert section_separator_idx > 0, "§9/§10 separator not found"
+        assert section_9_mermaid_idx < section_separator_idx, (
+            "Mermaid Diagrams subsection must appear before the §9/§10 separator"
+        )
+
+    def test_toc_has_mermaid_diagrams_entry(self) -> None:
+        text = self._contributing_text()
+        assert "- [Mermaid Diagrams](#mermaid-diagrams)" in text, (
+            "Table of Contents missing Mermaid Diagrams entry under §9"
+        )

--- a/tests/test_issue_127.py
+++ b/tests/test_issue_127.py
@@ -1,10 +1,8 @@
-"""Tests for issue #127 — FEATURE: Add CONTRIBUTING.md entry for Mermaid diagram authoring conventions."""
+"""Tests for issue #127 — FEATURE: Add CONTRIBUTING.md entry for Mermaid
+diagram authoring conventions."""
 
 from __future__ import annotations
 
-from pathlib import Path
-
-import pytest
 from conftest import REPO_ROOT
 
 CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"


### PR DESCRIPTION
## Summary
Resolves #127 — FEATURE: Add CONTRIBUTING.md entry for Mermaid diagram authoring conventions
## Changes
- Section 9 (Coding Standards) ends at line 338 with the "Diagram Files" subsection. There is no guidance on which Mermaid directive to use for which purpose, no heading convention, and no per-file validation command documented for contributors who want to validate a single diagram before opening a PR

**Tasks:**
- Add a "### Mermaid Diagrams" subsection to CONTRIBUTING.md §9 (Coding Standards)
- Include the directive-selection table (| Purpose | Directive |) with the three rows:
- Document the heading convention: `### Decision Flow` placed immediately after the
- Document the per-file local validation command:
- Update the Table of Contents at the top of CONTRIBUTING.md (lines 10-27) to add
- All existing and new tests pass locally (pytest / mvn test / npm test / etc.)
- All existing and new lint checks pass locally (ruff / eslint / ng lint / make ci etc.)
## Testing
Run the full test suite — all tests must pass.
Closes #127