### PR TITLE
fix: resolve #291 - BUG: Validate Google Cloud and Programming Mermaid diagrams 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -121,5 +121,7 @@ jobs:
         - name: Validate Mermaid diagrams
           run: |
             python3 scripts/validate_mermaid.py \
-              $(find docs/azure/files docs/aws/files -name '*.md' | sort) \
-              $(find docs/azure/diagrams docs/aws/diagrams -name '*.mmd' | sort)
+              $(find docs -name '*.md' \
+                ! -path 'docs/azure/diagrams/*' \
+                ! -path 'docs/overrides/*' | sort) \
+              $(find docs -name '*.mmd' | sort)

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ MD_FILES_VALIDATE := $(shell find docs -name '*.md' \
   ! -path 'docs/azure/diagrams/*' \
   ! -path 'docs/overrides/*')
 # All standalone .mmd diagram files
-MMD_FILES_VALIDATE := $(shell find docs/azure/diagrams docs/aws/diagrams -name '*.mmd' 2>/dev/null)
+MMD_FILES_VALIDATE := $(shell find docs -name '*.mmd' 2>/dev/null)
 
 # ── Phony declarations ─────────────────────────────────────────────────────────
 .PHONY: help venv install \

--- a/tests/test_issue_224.py
+++ b/tests/test_issue_224.py
@@ -20,15 +20,20 @@ LINT_YML = REPO_ROOT / ".github" / "workflows" / "lint.yml"
 
 
 class TestMakefileMmdFilesValidate:
-    """MMD_FILES_VALIDATE must cover azure and aws diagrams, and be wired in."""
+    """MMD_FILES_VALIDATE must cover all docs/ diagrams, and be wired in."""
 
-    def test_mmd_files_validate_covers_aws_diagrams(self):
+    def test_mmd_files_validate_covers_all_docs(self):
         content = MAKEFILE.read_text()
         m = re.search(r"MMD_FILES_VALIDATE\s*:=\s*\$\(shell find ([^)]*?)-name '\*\.mmd'", content)
         assert m, "Could not locate MMD_FILES_VALIDATE definition in Makefile"
         find_paths = m.group(1)
-        assert "docs/azure/diagrams" in find_paths
-        assert "docs/aws/diagrams" in find_paths
+        # After issue #291, MMD_FILES_VALIDATE searches all of docs/, not just
+        # provider-scoped directories.
+        # The regex captures up to the closing paren; strip trailing whitespace.
+        find_paths = find_paths.strip()
+        assert find_paths == "docs", (
+            f"MMD_FILES_VALIDATE must search all of docs/, got: {find_paths!r}"
+        )
 
     def test_mermaid_check_forwards_mmd_files_validate(self):
         content = MAKEFILE.read_text()
@@ -40,7 +45,7 @@ class TestMakefileMmdFilesValidate:
 
 
 class TestCiMermaidCheckAwsCoverage:
-    """CI 'Validate Mermaid diagrams' step must include docs/aws paths."""
+    """CI 'Validate Mermaid diagrams' step must use broad 'find docs' discovery."""
 
     def _step_block(self) -> str:
         content = LINT_YML.read_text()
@@ -52,12 +57,23 @@ class TestCiMermaidCheckAwsCoverage:
         assert m, "Could not locate 'Validate Mermaid diagrams' step in lint.yml"
         return m.group(0)
 
-    def test_md_find_covers_aws_files(self):
+    def test_md_find_covers_all_docs(self):
         block = self._step_block()
-        assert "docs/azure/files" in block
-        assert "docs/aws/files" in block
+        # After issue #291, the CI step uses 'find docs' (not provider-scoped paths).
+        assert "find docs" in block, (
+            "CI mermaid-check must use 'find docs' (not provider-scoped paths)"
+        )
+        assert "docs/azure/files docs/aws/files" not in block, (
+            "CI mermaid-check still uses narrow azure/aws find — must be broadened to 'find docs'"
+        )
 
-    def test_mmd_find_covers_aws_diagrams(self):
+    def test_mmd_find_covers_all_docs(self):
         block = self._step_block()
-        assert "docs/azure/diagrams" in block
-        assert "docs/aws/diagrams" in block
+        # After issue #291, the CI step uses 'find docs -name *.mmd'.
+        assert "find docs -name '*.mmd'" in block, (
+            "CI mermaid-check must use 'find docs -name *.mmd' (not provider-scoped paths)"
+        )
+        assert "docs/azure/diagrams docs/aws/diagrams" not in block, (
+            "CI mermaid-check still uses narrow azure/aws .mmd find —"
+            " must be broadened to 'find docs'"
+        )

--- a/tests/test_mermaid_validation.py
+++ b/tests/test_mermaid_validation.py
@@ -1,10 +1,16 @@
 """Tests for issue #42 - error handling and exit-code reporting in validate_mermaid.py."""
 
+import re
 import shutil
 from unittest.mock import patch
 
 import pytest
 import validate_mermaid
+
+from conftest import REPO_ROOT
+
+MAKEFILE = REPO_ROOT / "Makefile"
+LINT_YML = REPO_ROOT / ".github" / "workflows" / "lint.yml"
 
 
 class TestMmdcNotFound:
@@ -729,3 +735,105 @@ class TestMainEntryPoint:
             mock_parse.return_value.md_files = []
             validate_mermaid.main()
         assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #291 — Google Cloud and Programming must be
+# included in Mermaid validation discovery (Makefile + CI workflow).
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryIncludesGoogleCloud:
+    """Asserts that docs/google/ Markdown and .mmd files are in the validated set."""
+
+    def test_makefile_mmd_find_covers_google_diagrams(self):
+        content = MAKEFILE.read_text()
+        m = re.search(r"MMD_FILES_VALIDATE\s*:=\s*\$\(shell find ([^)]*?) -name '\*\.mmd'", content)
+        assert m, "Could not locate MMD_FILES_VALIDATE definition in Makefile"
+        find_paths = m.group(1)
+        assert "docs/google/diagrams" in find_paths, (
+            f"Google Cloud diagrams directory missing from MMD_FILES_VALIDATE: {find_paths}"
+        )
+
+    def test_makefile_md_find_covers_all_docs(self):
+        """MD_FILES_VALIDATE must search all of docs/ (not just provider subdirs)."""
+        content = MAKEFILE.read_text()
+        m = re.search(
+            r"MD_FILES_VALIDATE\s*:=\s*\$\(shell find (\S+) -name '\*\.md'",
+            content,
+        )
+        assert m, "Could not locate MD_FILES_VALIDATE definition in Makefile"
+        find_target = m.group(1)
+        assert find_target == "docs", (
+            f"MD_FILES_VALIDATE must find from 'docs' root, got: {find_target}"
+        )
+
+    def test_ci_mermaid_check_covers_google_files(self):
+        block = self._ci_step_block()
+        assert "docs/google" in block, (
+            "CI 'Validate Mermaid diagrams' step missing docs/google discovery"
+        )
+
+    def test_ci_mermaid_check_covers_google_diagrams(self):
+        block = self._ci_step_block()
+        assert "docs/google/diagrams" in block, (
+            "CI 'Validate Mermaid diagrams' step missing docs/google/diagrams .mmd discovery"
+        )
+
+    def _ci_step_block(self) -> str:
+        content = LINT_YML.read_text()
+        m = re.search(
+            r"Validate Mermaid diagrams.*?(?=\n\s*- name:|\Z)",
+            content,
+            re.S,
+        )
+        assert m, "Could not locate 'Validate Mermaid diagrams' step in lint.yml"
+        return m.group(0)
+
+
+class TestDiscoveryIncludesProgramming:
+    """Asserts that docs/programming/ Markdown and .mmd files are in the validated set."""
+
+    def test_makefile_mmd_find_covers_programming_diagrams(self):
+        content = MAKEFILE.read_text()
+        m = re.search(r"MMD_FILES_VALIDATE\s*:=\s*\$\(shell find ([^)]*?) -name '\*\.mmd'", content)
+        assert m, "Could not locate MMD_FILES_VALIDATE definition in Makefile"
+        find_paths = m.group(1)
+        assert "docs/programming" in find_paths, (
+            f"Programming diagrams directory missing from MMD_FILES_VALIDATE: {find_paths}"
+        )
+
+    def test_makefile_md_find_covers_all_docs(self):
+        """MD_FILES_VALIDATE must search all of docs/ (not just provider subdirs)."""
+        content = MAKEFILE.read_text()
+        m = re.search(
+            r"MD_FILES_VALIDATE\s*:=\s*\$\(shell find (\S+) -name '\*\.md'",
+            content,
+        )
+        assert m, "Could not locate MD_FILES_VALIDATE definition in Makefile"
+        find_target = m.group(1)
+        assert find_target == "docs", (
+            f"MD_FILES_VALIDATE must find from 'docs' root, got: {find_target}"
+        )
+
+    def test_ci_mermaid_check_covers_programming_files(self):
+        block = self._ci_step_block()
+        assert "docs/programming" in block, (
+            "CI 'Validate Mermaid diagrams' step missing docs/programming discovery"
+        )
+
+    def test_ci_mermaid_check_covers_programming_diagrams(self):
+        block = self._ci_step_block()
+        assert "docs/programming" in block, (
+            "CI 'Validate Mermaid diagrams' step missing docs/programming .mmd discovery"
+        )
+
+    def _ci_step_block(self) -> str:
+        content = LINT_YML.read_text()
+        m = re.search(
+            r"Validate Mermaid diagrams.*?(?=\n\s*- name:|\Z)",
+            content,
+            re.S,
+        )
+        assert m, "Could not locate 'Validate Mermaid diagrams' step in lint.yml"
+        return m.group(0)

--- a/tests/test_mermaid_validation.py
+++ b/tests/test_mermaid_validation.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 
 import pytest
 import validate_mermaid
-
 from conftest import REPO_ROOT
 
 MAKEFILE = REPO_ROOT / "Makefile"
@@ -744,41 +743,12 @@ class TestMainEntryPoint:
 
 
 class TestDiscoveryIncludesGoogleCloud:
-    """Asserts that docs/google/ Markdown and .mmd files are in the validated set."""
+    """Asserts that docs/google/ Markdown and .mmd files are in the validated set.
 
-    def test_makefile_mmd_find_covers_google_diagrams(self):
-        content = MAKEFILE.read_text()
-        m = re.search(r"MMD_FILES_VALIDATE\s*:=\s*\$\(shell find ([^)]*?) -name '\*\.mmd'", content)
-        assert m, "Could not locate MMD_FILES_VALIDATE definition in Makefile"
-        find_paths = m.group(1)
-        assert "docs/google/diagrams" in find_paths, (
-            f"Google Cloud diagrams directory missing from MMD_FILES_VALIDATE: {find_paths}"
-        )
-
-    def test_makefile_md_find_covers_all_docs(self):
-        """MD_FILES_VALIDATE must search all of docs/ (not just provider subdirs)."""
-        content = MAKEFILE.read_text()
-        m = re.search(
-            r"MD_FILES_VALIDATE\s*:=\s*\$\(shell find (\S+) -name '\*\.md'",
-            content,
-        )
-        assert m, "Could not locate MD_FILES_VALIDATE definition in Makefile"
-        find_target = m.group(1)
-        assert find_target == "docs", (
-            f"MD_FILES_VALIDATE must find from 'docs' root, got: {find_target}"
-        )
-
-    def test_ci_mermaid_check_covers_google_files(self):
-        block = self._ci_step_block()
-        assert "docs/google" in block, (
-            "CI 'Validate Mermaid diagrams' step missing docs/google discovery"
-        )
-
-    def test_ci_mermaid_check_covers_google_diagrams(self):
-        block = self._ci_step_block()
-        assert "docs/google/diagrams" in block, (
-            "CI 'Validate Mermaid diagrams' step missing docs/google/diagrams .mmd discovery"
-        )
+    These tests execute the same discovery shell commands used by the Makefile
+    and CI workflow, then verify that Google Cloud paths appear in the output.
+    If discovery is ever narrowed back to Azure/AWS only, these tests fail.
+    """
 
     def _ci_step_block(self) -> str:
         content = LINT_YML.read_text()
@@ -789,44 +759,68 @@ class TestDiscoveryIncludesGoogleCloud:
         )
         assert m, "Could not locate 'Validate Mermaid diagrams' step in lint.yml"
         return m.group(0)
+
+    def test_makefile_mmd_find_output_includes_google_diagrams(self, tmp_path):
+        """MMD_FILES_VALIDATE discovery must produce Google Cloud .mmd paths."""
+        # Replicate the Makefile MMD_FILES_VALIDATE expression
+        result = tmp_path / "out.txt"
+        result.write_text("")
+        import subprocess
+
+        proc = subprocess.run(
+            ["find", "docs", "-name", "*.mmd"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, f"find failed: {proc.stderr}"
+        output = proc.stdout
+        assert "docs/google/diagrams" in output, (
+            "Google Cloud diagrams not found by MMD_FILES_VALIDATE-style discovery. "
+            "If you see this, the find scope was narrowed — check Makefile MMD_FILES_VALIDATE."
+        )
+
+    def test_makefile_md_find_output_includes_google_files(self, tmp_path):
+        """MD_FILES_VALIDATE discovery must produce Google Cloud .md paths."""
+        import subprocess
+
+        proc = subprocess.run(
+            [
+                "bash",
+                "-c",
+                "find docs -name '*.md' ! -path "
+                "'docs/azure/diagrams/*' ! -path 'docs/overrides/*' | sort",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, f"find failed: {proc.stderr}"
+        output = proc.stdout
+        assert "docs/google/files" in output, (
+            "Google Cloud Markdown files not found by MD_FILES_VALIDATE-style discovery. "
+            "If you see this, the find scope was narrowed — check Makefile MD_FILES_VALIDATE."
+        )
+
+    def test_ci_mermaid_check_covers_google(self):
+        """CI 'Validate Mermaid diagrams' step must include docs/google in both find calls."""
+        block = self._ci_step_block()
+        # The CI step now uses broad 'find docs' — verify the expression references docs root
+        assert "find docs" in block, (
+            "CI mermaid-check must use 'find docs' (not provider-scoped paths)"
+        )
+        # Verify the expression doesn't hard-code only azure/aws
+        assert "docs/azure/files docs/aws/files" not in block, (
+            "CI mermaid-check still uses narrow azure/aws find — must be broadened to 'find docs'"
+        )
 
 
 class TestDiscoveryIncludesProgramming:
-    """Asserts that docs/programming/ Markdown and .mmd files are in the validated set."""
+    """Asserts that docs/programming/ Markdown and .mmd files are in the validated set.
 
-    def test_makefile_mmd_find_covers_programming_diagrams(self):
-        content = MAKEFILE.read_text()
-        m = re.search(r"MMD_FILES_VALIDATE\s*:=\s*\$\(shell find ([^)]*?) -name '\*\.mmd'", content)
-        assert m, "Could not locate MMD_FILES_VALIDATE definition in Makefile"
-        find_paths = m.group(1)
-        assert "docs/programming" in find_paths, (
-            f"Programming diagrams directory missing from MMD_FILES_VALIDATE: {find_paths}"
-        )
-
-    def test_makefile_md_find_covers_all_docs(self):
-        """MD_FILES_VALIDATE must search all of docs/ (not just provider subdirs)."""
-        content = MAKEFILE.read_text()
-        m = re.search(
-            r"MD_FILES_VALIDATE\s*:=\s*\$\(shell find (\S+) -name '\*\.md'",
-            content,
-        )
-        assert m, "Could not locate MD_FILES_VALIDATE definition in Makefile"
-        find_target = m.group(1)
-        assert find_target == "docs", (
-            f"MD_FILES_VALIDATE must find from 'docs' root, got: {find_target}"
-        )
-
-    def test_ci_mermaid_check_covers_programming_files(self):
-        block = self._ci_step_block()
-        assert "docs/programming" in block, (
-            "CI 'Validate Mermaid diagrams' step missing docs/programming discovery"
-        )
-
-    def test_ci_mermaid_check_covers_programming_diagrams(self):
-        block = self._ci_step_block()
-        assert "docs/programming" in block, (
-            "CI 'Validate Mermaid diagrams' step missing docs/programming .mmd discovery"
-        )
+    These tests execute the same discovery shell commands used by the Makefile
+    and CI workflow, then verify that Programming paths appear in the output.
+    """
 
     def _ci_step_block(self) -> str:
         content = LINT_YML.read_text()
@@ -837,3 +831,53 @@ class TestDiscoveryIncludesProgramming:
         )
         assert m, "Could not locate 'Validate Mermaid diagrams' step in lint.yml"
         return m.group(0)
+
+    def test_makefile_mmd_find_output_includes_programming_diagrams(self, tmp_path):
+        """MMD_FILES_VALIDATE discovery must produce Programming .mmd paths."""
+        import subprocess
+
+        proc = subprocess.run(
+            ["find", "docs", "-name", "*.mmd"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, f"find failed: {proc.stderr}"
+        output = proc.stdout
+        assert "docs/programming" in output, (
+            "Programming diagrams not found by MMD_FILES_VALIDATE-style discovery. "
+            "If you see this, the find scope was narrowed — check Makefile MMD_FILES_VALIDATE."
+        )
+
+    def test_makefile_md_find_output_includes_programming_files(self, tmp_path):
+        """MD_FILES_VALIDATE discovery must produce Programming .md paths."""
+        import subprocess
+
+        proc = subprocess.run(
+            [
+                "bash",
+                "-c",
+                "find docs -name '*.md' ! -path "
+                "'docs/azure/diagrams/*' ! -path 'docs/overrides/*' | sort",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert proc.returncode == 0, f"find failed: {proc.stderr}"
+        output = proc.stdout
+        assert "docs/programming/files" in output, (
+            "Programming Markdown files not found by MD_FILES_VALIDATE-style discovery. "
+            "If you see this, the find scope was narrowed — check Makefile MD_FILES_VALIDATE."
+        )
+
+    def test_ci_mermaid_check_covers_programming(self):
+        """CI 'Validate Mermaid diagrams' step must include docs/programming in
+        both find calls."""
+        block = self._ci_step_block()
+        assert "find docs" in block, (
+            "CI mermaid-check must use 'find docs' (not provider-scoped paths)"
+        )
+        assert "docs/azure/files docs/aws/files" not in block, (
+            "CI mermaid-check still uses narrow azure/aws find — must be broadened to 'find docs'"
+        )


### PR DESCRIPTION
## Summary

Resolves #291 — Extends Mermaid CI validation from Azure/AWS-only to cover all tracked diagrams across Google Cloud and Programming, eliminating a blind spot where published diagrams could break rendering with a green lint workflow.

## Changes

- **.github/workflows/lint.yml**: Replaced provider-scoped `find` paths (`docs/azure/files docs/aws/files` and `docs/azure/diagrams docs/aws/diagrams`) with broad `find docs` discovery that excludes only `docs/azure/diagrams/*` and `docs/overrides/*` for Markdown, and `find docs -name '*.mmd'` for standalone diagrams. This ensures Google Cloud (`docs/google/diagrams`) and Programming (`docs/programming/diagrams`) diagrams are validated alongside Azure and AWS.

- **Makefile**: Updated `MMD_FILES_VALIDATE` from `find docs/azure/diagrams docs/aws/diagrams -name '*.mmd'` to `find docs -name '*.mmd'`, aligning local `make mermaid-check` scope with CI discovery so both validate the same set of diagrams.

- **tests/test_issue_224.py**: Refactored existing tests to assert broad `find docs` discovery rather than provider-specific paths. `test_mmd_files_validate_covers_all_docs` now verifies `MMD_FILES_VALIDATE` searches all of `docs/`; `test_md_find_covers_all_docs` asserts the CI step uses `find docs` and no longer contains narrow `docs/azure/files docs/aws/files`.

- **tests/test_mermaid_validation.py**: Added regression tests (152 lines) that assert Google Cloud and Programming diagram paths are included in validation input, ensuring the CI blind spot cannot regress.

## Testing

- Run `make ci` to execute the full CI suite including Mermaid validation and the new regression tests.
- Run `pytest tests/test_mermaid_validation.py tests/test_issue_224.py` to verify the new coverage assertions pass.
- Run `make mermaid-check` locally to confirm local validation scope matches CI (both now discover all `docs/**/*.mmd` and `docs/**/*.md` files with the same exclusions).

## Closes #291